### PR TITLE
Prepare for hpgsql-simple-compat on Hackage

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -61,7 +61,14 @@ jobs:
 
     - name: Run hpgsql-simple-compat tests
       run: |
-        scripts/ci/run-tests-and-annotate-with-error.sh local/hpgsql-simple-compat-tests.txt nix-build --no-out-link -A hpgsqlSimpleCompatTestsPg18
+        concurrently -g --timings --names pg18,pg17,pg16,pg15,pg14,ghc984,ghc967 \
+          'timeout 5m scripts/ci/run-tests-and-annotate-with-error.sh local/pg18-simple-compat-tests.txt nix-build --no-out-link -A hpgsqlSimpleCompatTestsPg18' \
+          'timeout 5m scripts/ci/run-tests-and-annotate-with-error.sh local/pg17-simple-compat-tests.txt nix-build --no-out-link -A hpgsqlSimpleCompatTestsPg17' \
+          'timeout 5m scripts/ci/run-tests-and-annotate-with-error.sh local/pg16-simple-compat-tests.txt nix-build --no-out-link -A hpgsqlSimpleCompatTestsPg16' \
+          'timeout 5m scripts/ci/run-tests-and-annotate-with-error.sh local/pg15-simple-compat-tests.txt nix-build --no-out-link -A hpgsqlSimpleCompatTestsPg15' \
+          'timeout 5m scripts/ci/run-tests-and-annotate-with-error.sh local/pg14-simple-compat-tests.txt nix-build --no-out-link -A hpgsqlSimpleCompatTestsPg14' \
+          'nix-build --no-out-link --argstr ghc ghc984 -A hpgsql-tests && timeout 5m scripts/ci/run-tests-and-annotate-with-error.sh local/pg18-ghc984-simple-compat-tests.txt nix-build --no-out-link --argstr ghc ghc984 -A hpgsqlSimpleCompatTestsPg18' \
+          'nix-build --no-out-link --argstr ghc ghc967 -A hpgsql-tests && timeout 5m scripts/ci/run-tests-and-annotate-with-error.sh local/pg18-ghc967-simple-compat-tests.txt nix-build --no-out-link --argstr ghc ghc967 -A hpgsqlSimpleCompatTestsPg18'
 
   build-aarch64-darwin:
     runs-on: macos-14
@@ -129,7 +136,7 @@ jobs:
           trusted-public-keys = mzabani.cachix.org-1:wnkKakfl+rbT7zTtV1P1tAtjBTuh6GQVX7LfSd9sMbA= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
 
     - name: Run hlint and `cabal check`
-      run: nix-shell --run 'hlint . && cd hpgsql && cabal check && cd -'
+      run: nix-shell --run 'hlint . && cd hpgsql && cabal check && cd ../hpgsql-simple-compat && cabal check && cd ..'
 
     - name: Check code is formatted
       run: |

--- a/default.nix
+++ b/default.nix
@@ -19,6 +19,10 @@ rec {
   inherit haskellPackages;
 
   hpgsqlSimpleCompatTestsPg18 = { hspecArgs ? ""}: import ./nix/run-hpgsql-simple-compat-db-tests.nix { inherit pkgs hpgsql-simple-compat-tests hspecArgs; postgres = addPgExtensions pkgs.postgresql_18; };
+  hpgsqlSimpleCompatTestsPg17 = { hspecArgs ? ""}: import ./nix/run-hpgsql-simple-compat-db-tests.nix { inherit pkgs hpgsql-simple-compat-tests hspecArgs; postgres = addPgExtensions pkgs.postgresql_17; };
+  hpgsqlSimpleCompatTestsPg16 = { hspecArgs ? ""}: import ./nix/run-hpgsql-simple-compat-db-tests.nix { inherit pkgs hpgsql-simple-compat-tests hspecArgs; postgres = addPgExtensions pkgs.postgresql_16; };
+  hpgsqlSimpleCompatTestsPg15 = { hspecArgs ? ""}: import ./nix/run-hpgsql-simple-compat-db-tests.nix { inherit pkgs hpgsql-simple-compat-tests hspecArgs; postgres = addPgExtensions pkgs.postgresql_15; };
+  hpgsqlSimpleCompatTestsPg14 = { hspecArgs ? ""}: import ./nix/run-hpgsql-simple-compat-db-tests.nix { inherit pkgs hpgsql-simple-compat-tests hspecArgs; postgres = addPgExtensions pkgs.postgresql_14; };
   testsPg18 = { hspecArgs ? ""}: import ./nix/run-db-tests.nix { inherit pkgs hpgsql-tests hspecArgs; postgres = addPgExtensions pkgs.postgresql_18; };
   testsPg17 = { hspecArgs ? ""}: import ./nix/run-db-tests.nix { inherit pkgs hpgsql-tests hspecArgs; postgres = addPgExtensions pkgs.postgresql_17; };
   testsPg16 = { hspecArgs ? ""}: import ./nix/run-db-tests.nix { inherit pkgs hpgsql-tests hspecArgs; postgres = addPgExtensions pkgs.postgresql_16; };

--- a/hpgsql-simple-compat/hpgsql-simple-compat.cabal
+++ b/hpgsql-simple-compat/hpgsql-simple-compat.cabal
@@ -1,9 +1,11 @@
 cabal-version:      1.12
 name:               hpgsql-simple-compat
-version:            0.7.0.1
-synopsis:           Mid-Level PostgreSQL client library
+version:            0.1.0.0
+synopsis:           Fork of postgresql-simple implemented with hpgsql instead of postgresql-libpq.
 description:
-  Mid-Level PostgreSQL client library, forked from mysql-simple.
+  This is a fork of postgresql-simple that tries to preserve its API as much as possible, but
+  uses hpgsql instead of postgresql-libpq under the hood.
+  The idea is to ease migrating to hpgsql itself. Check the GitHub for more information.
 
 license:            BSD3
 license-file:       LICENSE
@@ -19,10 +21,13 @@ copyright:
   (c) 2010 Grant Monroe
 
 category:           Database
+homepage:           https://github.com/mzabani/hpgsql#readme
+bug-reports:        https://github.com/mzabani/hpgsql/issues
 build-type:         Simple
-extra-source-files:
-  CHANGES.md
-  CONTRIBUTORS
+
+source-repository head
+  type:     git
+  location: http://github.com/mzabani/hpgsql/hpgsql-simple-compat
 
 library
   default-language:   Haskell2010
@@ -79,25 +84,25 @@ library
 
   -- GHC bundled libs
   build-depends:
-      base
-    , bytestring
-    , case-insensitive
-    , containers
-    , template-haskell
-    , text
-    , aeson
-    , attoparsec
-    , haskell-src-meta
-    , hpgsql
-    , hashable
-    , mtl
-    , streaming
-    , time-compat
-    , transformers
-    , Only
-    , scientific
-    , uuid-types
-    , vector
+      base >= 4.18 && < 4.21
+    , bytestring >= 0.11 && < 0.13
+    , case-insensitive >= 1.2 && < 1.3
+    , containers >= 0.6 && < 0.8
+    , template-haskell >= 2.20 && < 2.23
+    , text >= 2.0 && < 2.2
+    , aeson >= 2.2 && < 2.3
+    , attoparsec >= 0.14 && < 0.15
+    , haskell-src-meta >= 0.8 && < 0.9
+    , hpgsql >= 0.1 && < 0.2
+    , hashable >= 1.5 && < 1.6
+    , mtl >= 2.3 && < 2.4
+    , streaming >= 0.2 && < 0.3
+    , time-compat >= 1.9 && < 1.10
+    , transformers >= 0.6 && < 0.7
+    , Only >= 0.1 && < 0.2
+    , scientific >= 0.3 && < 0.4
+    , uuid-types >= 1.0 && < 1.1
+    , vector >= 0.13 && < 0.14
 
   default-extensions:
       CPP
@@ -136,8 +141,4 @@ library
       TemplateHaskell
       ViewPatterns
 
-  ghc-options: -O1 -Wall -fno-warn-name-shadowing
-
-source-repository head
-  type:     git
-  location: http://github.com/mzabani/hpgsql/hpgsql-simple-compat
+  ghc-options: -Wall -Wincomplete-uni-patterns -Wunused-packages -Wpartial-fields -optP-Wno-nonportable-include-path -fno-warn-name-shadowing


### PR DESCRIPTION
This tests hpgsql-simple-compat with all supported versions of postgresql, sets its version to 0.1.0.0, and changes the package description and instructions a little bit.