### PR TITLE
Only use atomic IORef writes

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -31,4 +31,7 @@
   - {name: "Data.List.NonEmpty.!!", within: [], message: "(!!) is partial. Use safe indexing instead."}
   - {name: "waitReadSocketSTM", within: [], message: "waitReadSocketSTM is not available in older versions of the network library. Use functions from our own Networking module instead."}
   - {name: "tryAny", within: [], message: "You typically want to ignore IrrecoverableHpgsqlError, so use tryJust instead"}
+  - {name: "writeIORef", within: [], message: "Are you sure you don't want to use atomicWriteIORef? Hpgsql being interruption-safe means a thread can resume the consumption of query results from a different thread, so it must read up-to-date buffers"}
+  - {name: "modifyIORef", within: [], message: "Are you sure you don't want to use atomicModifyIORef? Hpgsql being interruption-safe means a thread can resume the consumption of query results from a different thread, so it must read up-to-date buffers"}
+  - {name: "modifyIORef'", within: [], message: "Are you sure you don't want to use atomicModifyIORef'? Hpgsql being interruption-safe means a thread can resume the consumption of query results from a different thread, so it must read up-to-date buffers"}
   

--- a/hpgsql/src/Hpgsql/Internal.hs
+++ b/hpgsql/src/Hpgsql/Internal.hs
@@ -119,7 +119,7 @@ import Data.ByteString.Internal (w2c)
 import qualified Data.ByteString.Lazy as LBS
 import Data.Data (Proxy (..))
 import Data.Either (isLeft, isRight)
-import Data.IORef (newIORef, readIORef, writeIORef)
+import Data.IORef (atomicWriteIORef, newIORef, readIORef)
 import Data.Int (Int32, Int64)
 import qualified Data.List as List
 import Data.List.NonEmpty (NonEmpty (..))
@@ -534,7 +534,7 @@ receiveNextMsgWithMaskedContinuationButDontThrowOnParsingFailure conn@HPgConnect
     modifyIORefIO ioref io = do
       c <- readIORef ioref
       (newC, v) <- io c
-      writeIORef ioref newC
+      atomicWriteIORef ioref newC
       pure v
     -- We mask_ because if the supplied STM action runs with a message extracted from
     -- the recvBuffer, then we _must_ remove that message from recvBuffer.
@@ -594,7 +594,7 @@ receiveNextMsgWithMaskedContinuationButDontThrowOnParsingFailure conn@HPgConnect
           mask $ \restore -> rethrowAsIrrecoverable $ do
             restore $ socketWaitRead socket
             someBytes <- timeDebugNonBlockingOperation "recv" $ recvNonBlocking socket (max 16000 $ fromIntegral $ minBytesNecessary - nBytesInBuffer)
-            writeIORef recvBuffer (currentBuffer <> LBS.fromStrict someBytes)
+            atomicWriteIORef recvBuffer (currentBuffer <> LBS.fromStrict someBytes)
           receiveUntilBufferHasAtLeast minBytesNecessary
 
 sendCancellationRequest :: HPgConnection -> IO ()


### PR DESCRIPTION
Otherwise buffer health is at risk, and it's not worth it.

The previous commit claimed 3-3.5% reduction in runtime for a benchmark from a baseline, this now brings that improvement down to ~2%.