### PR TITLE
Performance improvement: do more work per buffer access

### DIFF
--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -29,18 +29,18 @@ The second column is wall clock time in seconds, the third is peak heap memory a
 
 This runs with 2 concurrent queries, 10 times over:
 ```csv
-postgresql-simple Record List (100000 rows),11.65,142.75M,89.1
-hasql Record List (100000 rows),6.660,142.48M,78.3
-hpgsql Record List (100000 rows),4.360,72.07M,82.3
+postgresql-simple Record List (100000 rows),11.90,142.65M,101.6
+hasql Record List (100000 rows),6.279,142.48M,78.0
+hpgsql Record List (100000 rows),3.886,72.07M,98.2
 ```
 
 ### Materializing 100_000 rows with 13 columns each into a List of Tuples
 
 This runs with 2 concurrent queries, 10 times over:
 ```csv
-postgresql-simple Tuple List (100000 rows),14.68,143.04M,146.2
-hasql Tuple List (100000 rows),8.999,142.48M,204.3
-hpgsql Tuple List (100000 rows),5.014,72.07M,149.1
+postgresql-simple Tuple List (100000 rows),15.03,142.78M,149.8
+hasql Tuple List (100000 rows),8.376,142.48M,195.4
+hpgsql Tuple List (100000 rows),4.689,72.07M,149.4
 ```
 
 ### Streaming 100_000 rows with 13 columns as Records
@@ -50,9 +50,9 @@ Hpgsql's implementation streams directly from the socket while the others use cu
 it might not be a fair comparison in terms of implementation (e.g. you can advance multiple
 cursors simultaneously, but not hpgsql's Streamed-from-socket streams).
 ```csv
-streaming-postgresql-simple Record Stream (100000 rows),13.36,73.30M,0.1
-postgresql-simple Record fold (100000 rows),13.46,77.53M,0.1
-hpgsql Record Stream (100000 rows),1.557,72.07M,0.2
+streaming-postgresql-simple Record Stream (100000 rows),16.69,73.24M,0.1
+postgresql-simple Record fold (100000 rows),13.39,78.29M,0.2
+hpgsql Record Stream (100000 rows),1.457,72.07M,0.2
 ```
 
 ### Streaming 100_000 rows with 13 columns as Tuples
@@ -62,9 +62,9 @@ Hpgsql's implementation streams directly from the socket while the others use cu
 it might not be a fair comparison in terms of implementation (e.g. you can advance multiple
 cursors simultaneously, but not hpgsql's Streamed-from-socket streams).
 ```csv
-streaming-postgresql-simple Tuple Stream (100000 rows),14.15,73.18M,0.1
-postgresql-simple Tuple fold (100000 rows),13.57,84.07M,0.2
-hpgsql Tuple Stream (100000 rows),1.195,72.07M,0.2
+streaming-postgresql-simple Tuple Stream (100000 rows),13.89,73.28M,0.1
+postgresql-simple Tuple fold (100000 rows),13.69,81.99M,0.2
+hpgsql Tuple Stream (100000 rows),1.076,72.07M,0.2
 ```
 
 ### COPY FROM STDIN

--- a/README.md
+++ b/README.md
@@ -51,9 +51,9 @@ You should start by swapping all of "postgresql-simple", "postgresql-libpq", and
 
 ## Performance
 
-Some benchmarks show materializing large query results with hpgsql takes 34-38% the time postgresql-simple takes, and 56-66% the time hasql takes (on my computer, Linux x64, GHC 9.10.3, compiled with -O1).
+Some benchmarks show materializing large query results with hpgsql takes 31-33% the time postgresql-simple takes, and 56-62% the time hasql takes (on my computer, Linux x64, GHC 9.10.3, compiled with -O1).
 
-When comparing hpgsql's Stream querying, hpgsql takes 9-12% the time of both [streaming-postgresql-simple](https://hackage.haskell.org/package/streaming-postgresql-simple) and postgresql-simple's cursor folding functions, although this might not be a fair comparison for some use cases.
+When comparing hpgsql's Stream querying, hpgsql takes 9-11% the time of both [streaming-postgresql-simple](https://hackage.haskell.org/package/streaming-postgresql-simple) and postgresql-simple's cursor folding functions, although this might not be a fair comparison for some use cases.
 
 hpgsql's binary COPY runs in about 92% the time of postgresql-simple's textual COPY.
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,1 +1,0 @@
-- Document that Streams must be consumed linearly with a clear example in queryS, queryMS, pipelineS

--- a/TODO.md
+++ b/TODO.md
@@ -1,10 +1,1 @@
-- Add a bunch more types and instances
-  - hstore
-  - PGRange?
-- Get rid of Time.hs? Move Unbounded to Types.hs?
-- A newtype that changes `ToPgRow` to encode `Int` as an `Int32`?
-
-## Less important:
-- Experiment with TCP NoDelay
-- Connecting with TLS encrypted connection (can come later?)
-- Connecting should use PGUSER, PGDATABASE, PGPORT, etc., when the equivalent values are not provided. Or should it?
+- Document that Streams must be consumed linearly with a clear example in queryS, queryMS, pipelineS

--- a/hpgsql-tests/NotificationsSpec.hs
+++ b/hpgsql-tests/NotificationsSpec.hs
@@ -2,6 +2,8 @@ module NotificationsSpec where
 
 import Control.Concurrent (myThreadId, threadDelay)
 import Control.Concurrent.Async (wait, withAsync)
+import Control.Monad (forM_)
+import qualified Data.Text as Text
 import DbUtils
   ( aroundConn,
     irrecoverableErrorWithMsg,
@@ -11,6 +13,8 @@ import Hpgsql
 import Hpgsql.Connection (getBackendPid, resetConnectionState, withConnection)
 import Hpgsql.Notification (NotificationResponse (..), getNotification, getNotificationNonBlocking)
 import Hpgsql.Query (sql)
+import Hpgsql.Types (Only (..))
+import qualified Streaming.Prelude as S
 import System.Timeout (timeout)
 import Test.Hspec
 
@@ -20,6 +24,10 @@ spec = do
     it
       "Send notifications and then receive them"
       sendNotifAndReceiveIt
+
+    it
+      "Receiving notifications while consuming query results"
+      receivingNotificationsWhileConsumingQueryResults
 
     it
       "Mixing order of sending and receiving notifications"
@@ -51,6 +59,20 @@ sendNotifAndReceiveIt conn = do
   execute_ conn "NOTIFY test_chan, 'hello again'"
   execute_ conn "SELECT 91" -- Ensure NotificationResponse can be received at any time
   getNotification conn `shouldReturn` NotificationResponse {notifierPid = currentPid, channelName = "test_chan", notifPayload = "hello again"}
+
+receivingNotificationsWhileConsumingQueryResults :: HPgConnection -> IO ()
+receivingNotificationsWhileConsumingQueryResults conn = do
+  execute_ conn "LISTEN multi_chan"
+  hpgsqlConnInfo <- testConnInfo
+  withConnection hpgsqlConnInfo 10 $ \conn2 -> do
+    withAsync (forM_ [30000 .. 31000] $ \i -> execute_ conn2 [sql|SELECT pg_notify('multi_chan', #{show i})|]) $ \notifier -> do
+      s <- queryS conn "SELECT * FROM generate_series(1,1000)"
+      map fromOnly <$> S.toList_ s `shouldReturn` [1 :: Int .. 1000]
+      forM_ [30000 .. 31000] $ \i -> do
+        notif <- getNotification conn
+        notif.channelName `shouldBe` "multi_chan"
+        notif.notifPayload `shouldBe` Text.pack (show i)
+      wait notifier
 
 mixedOrderSendAndReceiveNotifications :: HPgConnection -> IO ()
 mixedOrderSendAndReceiveNotifications conn = do

--- a/hpgsql-tests/NotificationsSpec.hs
+++ b/hpgsql-tests/NotificationsSpec.hs
@@ -20,7 +20,7 @@ import Test.Hspec
 
 spec :: Spec
 spec = do
-  aroundConn $ describe "Notifications" $ do
+  aroundConn $ describe "Notifications" $ parallel $ do
     it
       "Send notifications and then receive them"
       sendNotifAndReceiveIt

--- a/hpgsql-tests/ThreadSafetySpec.hs
+++ b/hpgsql-tests/ThreadSafetySpec.hs
@@ -214,8 +214,8 @@ sendQueriesConcurrently conn = forConcurrently_ [1 .. 10] $ const $ do
 cancelStreamingQueryThenTryToConsumeResults :: HPgConnection -> IO ()
 cancelStreamingQueryThenTryToConsumeResults conn = do
   res <- querySWith (rowDecoder @(Only Int)) conn "SELECT * FROM generate_series(1,100000000)"
-  firstTwoElems <- S.toList_ $ S.take 2 res
-  thirdAndFourthElems :> restOfStream <- S.toList $ S.splitAt 2 res
+  firstTwoElems :> restOfStream0 <- S.toList $ S.splitAt 2 res
+  thirdAndFourthElems :> restOfStream <- S.toList $ S.splitAt 2 restOfStream0
   fifthAndSixthElems <- S.toList_ $ S.take 2 restOfStream
   firstTwoElems `shouldBe` [Only 1, Only 2]
   thirdAndFourthElems `shouldBe` [Only 3, Only 4]

--- a/hpgsql/src/Hpgsql/Internal.hs
+++ b/hpgsql/src/Hpgsql/Internal.hs
@@ -505,13 +505,25 @@ receiveNextMsgWithMaskedContinuation conn parser f =
     Right p -> f p
     Left (msgIdentChar, mPgError) -> throw IrrecoverableHpgsqlError {hpgsqlDetails = "Could not parse postgres message with ident char " <> Text.pack (show msgIdentChar) <> ". This is an internal error in Hpgsql. Please report it.", innerException = toException <$> mPgError, relatedStatement = Nothing}
 
+data ReceiveWhat a where
+  ReceiveDataRows :: ReceiveWhat DataRow
+  ReceiveArbitraryMsg :: PgMsgParser a -> ReceiveWhat a
+
 -- | Masks asynchronous exceptions in between the moment the message is extracted from
 -- the internal buffer and the supplied function runs to completion.
 -- This is important for control messages (i.e. not `DataRow`) because if you extract a
 -- message from the buffer, you must be able to update the connection's internal state,
 -- lest it will be left in a very broken place.
 receiveNextMsgWithMaskedContinuationButDontThrowOnParsingFailure :: (Show a) => HPgConnection -> PgMsgParser a -> (Either (Char, Maybe PostgresError) a -> STM b) -> IO b
-receiveNextMsgWithMaskedContinuationButDontThrowOnParsingFailure conn@HPgConnection {socket, recvBuffer} parser f = do
+receiveNextMsgWithMaskedContinuationButDontThrowOnParsingFailure conn parser f = join $ receiveNextMsgGeneric conn (ReceiveArbitraryMsg parser) (STM.atomically . f)
+
+-- | Masks asynchronous exceptions in between the moment the message is extracted from
+-- the internal buffer and the supplied function runs to completion.
+-- This is important for control messages (i.e. not `DataRow`) because if you extract a
+-- message from the buffer, you must be able to update the connection's internal state,
+-- lest it will be left in a very broken place.
+receiveNextMsgGeneric :: (Show a) => HPgConnection -> ReceiveWhat a -> (Either (Char, Maybe PostgresError) a -> b) -> IO b
+receiveNextMsgGeneric conn@HPgConnection {socket, recvBuffer} receiveWhat f = do
   -- We need to preserve the invariant that the internal buffer's first byte is
   -- always the first byte of a valid Message while keeping this function
   -- interruptible.
@@ -528,9 +540,12 @@ receiveNextMsgWithMaskedContinuationButDontThrowOnParsingFailure conn@HPgConnect
   restOfMsg <- LBS.drop 5 . LBS.take fullMessageLen <$> if bufLen >= fullMessageLen then pure currentBuf else receiveUntilBufferHasAtLeast fullMessageLen
   receivedNoticeOrParameterSoTryAgain <- go msgIdentChar restOfMsg fullMessageLen
   case receivedNoticeOrParameterSoTryAgain of
-    Nothing -> receiveNextMsgWithMaskedContinuationButDontThrowOnParsingFailure conn parser f
+    Nothing -> receiveNextMsgGeneric conn receiveWhat f
     Just res -> pure res
   where
+    parser = case receiveWhat of
+      ReceiveDataRows -> msgParser @DataRow
+      ReceiveArbitraryMsg p -> p
     modifyIORefIO ioref io = do
       c <- readIORef ioref
       (newC, v) <- io c
@@ -550,7 +565,7 @@ receiveNextMsgWithMaskedContinuationButDontThrowOnParsingFailure conn@HPgConnect
       case parsePgMessage msgIdentChar restOfMsg parser of
         Just msg -> do
           debugPrint $ "Received " ++ show msg
-          fmap (bufferWithoutMsg,) $ Just <$> STM.atomically (f (Right msg))
+          pure (bufferWithoutMsg, Just (f (Right msg)))
         Nothing -> do
           -- This could be a Notification, NOTICE or a ParameterStatus message, since these
           -- can be received _at any time_ according to the docs.
@@ -577,7 +592,7 @@ receiveNextMsgWithMaskedContinuationButDontThrowOnParsingFailure conn@HPgConnect
               -- Just in case this is a postgres error, it might include useful information,
               -- so we spit that out
               let mPgError = mkPostgresError "" <$> parsePgMessage msgIdentChar restOfMsg (msgParser @ErrorResponse)
-               in fmap (lbs,) $ Just <$> STM.atomically (f (Left (msgIdentChar, mPgError)))
+               in pure (lbs, Just $ f (Left (msgIdentChar, mPgError)))
 
     -- \| Appends into the internal buffer by reading from the socket
     -- until the buffer has at least N bytes.
@@ -870,11 +885,7 @@ consumeResults conn qryId = do
       let allOtherRows =
             S.unfold
               ( \() -> do
-                  -- This is a bit ugly, but we try very carefully not to bear the cost of STM
-                  -- transactions at all when receiving DataRows, since they can come in very large
-                  -- amounts, but we need to make sure the _other_ important messages, like ErrorResponse
-                  -- and CommandComplete, do update internal state.
-                  mRow <- receiveNextMsgWithMaskedContinuationButDontThrowOnParsingFailure conn (msgParser @DataRow) pure
+                  mRow <- receiveNextMsgGeneric conn ReceiveDataRows Prelude.id
                   case mRow of
                     Right row -> pure $ Right (row :> ())
                     Left _ -> do

--- a/hpgsql/src/Hpgsql/Internal.hs
+++ b/hpgsql/src/Hpgsql/Internal.hs
@@ -505,9 +505,9 @@ receiveNextMsgWithMaskedContinuation conn parser f =
     Right p -> f p
     Left (msgIdentChar, mPgError) -> throw IrrecoverableHpgsqlError {hpgsqlDetails = "Could not parse postgres message with ident char " <> Text.pack (show msgIdentChar) <> ". This is an internal error in Hpgsql. Please report it.", innerException = toException <$> mPgError, relatedStatement = Nothing}
 
-data ReceiveWhat a where
-  ReceiveDataRows :: ReceiveWhat DataRow
-  ReceiveArbitraryMsg :: PgMsgParser a -> ReceiveWhat a
+data ReceiveWhat a b where
+  ReceiveDataRows :: ReceiveWhat DataRow (Maybe DataRow)
+  ReceiveArbitraryMsg :: PgMsgParser a -> (Either (Char, Maybe PostgresError) a -> STM b) -> ReceiveWhat a b
 
 -- | Masks asynchronous exceptions in between the moment the message is extracted from
 -- the internal buffer and the supplied function runs to completion.
@@ -515,15 +515,15 @@ data ReceiveWhat a where
 -- message from the buffer, you must be able to update the connection's internal state,
 -- lest it will be left in a very broken place.
 receiveNextMsgWithMaskedContinuationButDontThrowOnParsingFailure :: (Show a) => HPgConnection -> PgMsgParser a -> (Either (Char, Maybe PostgresError) a -> STM b) -> IO b
-receiveNextMsgWithMaskedContinuationButDontThrowOnParsingFailure conn parser f = join $ receiveNextMsgGeneric conn (ReceiveArbitraryMsg parser) (STM.atomically . f)
+receiveNextMsgWithMaskedContinuationButDontThrowOnParsingFailure conn parser f = receiveNextMsgGeneric conn (ReceiveArbitraryMsg parser f)
 
 -- | Masks asynchronous exceptions in between the moment the message is extracted from
 -- the internal buffer and the supplied function runs to completion.
 -- This is important for control messages (i.e. not `DataRow`) because if you extract a
 -- message from the buffer, you must be able to update the connection's internal state,
 -- lest it will be left in a very broken place.
-receiveNextMsgGeneric :: (Show a) => HPgConnection -> ReceiveWhat a -> (Either (Char, Maybe PostgresError) a -> b) -> IO b
-receiveNextMsgGeneric conn@HPgConnection {socket, recvBuffer} receiveWhat f = do
+receiveNextMsgGeneric :: (Show a) => HPgConnection -> ReceiveWhat a b -> IO b
+receiveNextMsgGeneric conn@HPgConnection {socket, recvBuffer} receiveWhat = do
   -- We need to preserve the invariant that the internal buffer's first byte is
   -- always the first byte of a valid Message while keeping this function
   -- interruptible.
@@ -540,12 +540,9 @@ receiveNextMsgGeneric conn@HPgConnection {socket, recvBuffer} receiveWhat f = do
   restOfMsg <- LBS.drop 5 . LBS.take fullMessageLen <$> if bufLen >= fullMessageLen then pure currentBuf else receiveUntilBufferHasAtLeast fullMessageLen
   receivedNoticeOrParameterSoTryAgain <- go msgIdentChar restOfMsg fullMessageLen
   case receivedNoticeOrParameterSoTryAgain of
-    Nothing -> receiveNextMsgGeneric conn receiveWhat f
+    Nothing -> receiveNextMsgGeneric conn receiveWhat
     Just res -> pure res
   where
-    parser = case receiveWhat of
-      ReceiveDataRows -> msgParser @DataRow
-      ReceiveArbitraryMsg p -> p
     modifyIORefIO ioref io = do
       c <- readIORef ioref
       (newC, v) <- io c
@@ -562,37 +559,46 @@ receiveNextMsgGeneric conn@HPgConnection {socket, recvBuffer} receiveWhat f = do
               else
                 error "Bug in Hpgsql. Internal buffer's bytes weren't filled enough"
 
-      case parsePgMessage msgIdentChar restOfMsg parser of
-        Just msg -> do
-          debugPrint $ "Received " ++ show msg
-          pure (bufferWithoutMsg, Just (f (Right msg)))
-        Nothing -> do
-          -- This could be a Notification, NOTICE or a ParameterStatus message, since these
-          -- can be received _at any time_ according to the docs.
-          case parsePgMessage msgIdentChar restOfMsg (Left3 <$> msgParser @NotificationResponse <|> Middle3 <$> msgParser @NoticeResponse <|> Right3 <$> msgParser @ParameterStatus) of
-            Just (Left3 notifResponse) -> do
-              debugPrint "Received notification. Will add it to internal queue."
-              STM.atomically $ do
-                sttv <- STM.readTVar $ internalConnectionState conn
-                STM.writeTQueue (notificationsReceived sttv) notifResponse
-              pure (bufferWithoutMsg, Nothing)
-            Just (Middle3 (NoticeResponse details)) -> do
-              let severity =
-                    fromMaybe
-                      "Notice of unknown severity"
-                      (Map.lookup ErrorSeverity details)
-                  humanmsg = fromMaybe "no message" (Map.lookup ErrorHumanReadableMsg details)
-              Text.hPutStrLn stderr $ decodeUtf8 $ LBS.toStrict $ severity <> ": " <> humanmsg
-              pure (bufferWithoutMsg, Nothing)
-            Just (Right3 (ParameterStatus {..})) -> do
-              when (parameterName == "client_encoding" && parameterValue /= "UTF8") $ throwIrrecoverableError $ "Postgres sent us a change of client_encoding to not UTF8, and Hpgsql only supports UTF8. The encoding postgres sent us is " <> parameterValue
-              modifyMVar_ (parameterStatusMap conn) $ \(!paramMap) -> pure (Map.insert parameterName parameterValue paramMap)
-              pure (bufferWithoutMsg, Nothing)
-            Nothing ->
-              -- Just in case this is a postgres error, it might include useful information,
-              -- so we spit that out
-              let mPgError = mkPostgresError "" <$> parsePgMessage msgIdentChar restOfMsg (msgParser @ErrorResponse)
-               in pure (lbs, Just $ f (Left (msgIdentChar, mPgError)))
+      let handleUnknownMessage onError =
+            -- This could be a Notification, NOTICE or a ParameterStatus message, since these
+            -- can be received _at any time_ according to the docs.
+            case parsePgMessage msgIdentChar restOfMsg (Left3 <$> msgParser @NotificationResponse <|> Middle3 <$> msgParser @NoticeResponse <|> Right3 <$> msgParser @ParameterStatus) of
+              Just (Left3 notifResponse) -> do
+                debugPrint "Received notification. Will add it to internal queue."
+                STM.atomically $ do
+                  sttv <- STM.readTVar $ internalConnectionState conn
+                  STM.writeTQueue (notificationsReceived sttv) notifResponse
+                pure (bufferWithoutMsg, Nothing)
+              Just (Middle3 (NoticeResponse details)) -> do
+                let severity =
+                      fromMaybe
+                        "Notice of unknown severity"
+                        (Map.lookup ErrorSeverity details)
+                    humanmsg = fromMaybe "no message" (Map.lookup ErrorHumanReadableMsg details)
+                Text.hPutStrLn stderr $ decodeUtf8 $ LBS.toStrict $ severity <> ": " <> humanmsg
+                pure (bufferWithoutMsg, Nothing)
+              Just (Right3 (ParameterStatus {..})) -> do
+                when (parameterName == "client_encoding" && parameterValue /= "UTF8") $ throwIrrecoverableError $ "Postgres sent us a change of client_encoding to not UTF8, and Hpgsql only supports UTF8. The encoding postgres sent us is " <> parameterValue
+                modifyMVar_ (parameterStatusMap conn) $ \(!paramMap) -> pure (Map.insert parameterName parameterValue paramMap)
+                pure (bufferWithoutMsg, Nothing)
+              Nothing -> do
+                -- Just in case this is a postgres error, it might include useful information,
+                -- so we spit that out
+                let mPgError = mkPostgresError "" <$> parsePgMessage msgIdentChar restOfMsg (msgParser @ErrorResponse)
+                fmap (lbs,) $ Just <$> STM.atomically (onError (msgIdentChar, mPgError))
+      case receiveWhat of
+        ReceiveDataRows ->
+          case parsePgMessage msgIdentChar restOfMsg (msgParser @DataRow) of
+            Just msg -> do
+              debugPrint $ "Received " ++ show msg
+              pure (bufferWithoutMsg, Just (Just msg))
+            Nothing -> handleUnknownMessage $ const $ pure Nothing -- No error when we stop receiving a DataRow, only a Nothing
+        ReceiveArbitraryMsg parser f ->
+          case parsePgMessage msgIdentChar restOfMsg parser of
+            Just msg -> do
+              debugPrint $ "Received " ++ show msg
+              fmap (bufferWithoutMsg,) $ Just <$> STM.atomically (f (Right msg))
+            Nothing -> handleUnknownMessage (f . Left)
 
     -- \| Appends into the internal buffer by reading from the socket
     -- until the buffer has at least N bytes.
@@ -885,10 +891,10 @@ consumeResults conn qryId = do
       let allOtherRows =
             S.unfold
               ( \() -> do
-                  mRow <- receiveNextMsgGeneric conn ReceiveDataRows Prelude.id
+                  mRow <- receiveNextMsgGeneric conn ReceiveDataRows
                   case mRow of
-                    Right row -> pure $ Right (row :> ())
-                    Left _ -> do
+                    Just row -> pure $ Right (row :> ())
+                    Nothing -> do
                       stateAfterNextMsg <- snd <$> receiveOutstandingResponseMsgsAtomically thisThreadId conn qryId
                       case stateAfterNextMsg of
                         ErrorResponseReceived _ err -> do

--- a/hpgsql/src/Hpgsql/Internal.hs
+++ b/hpgsql/src/Hpgsql/Internal.hs
@@ -115,6 +115,7 @@ import qualified Control.Concurrent.STM as STM
 import Control.Exception.Safe (Exception (..), MonadThrow, SomeException, bracket, bracketOnError, finally, handleJust, mask, mask_, onException, throw, toException, tryJust)
 import Control.Monad (forM, forM_, join, unless, void, when)
 import Data.ByteString (ByteString)
+import qualified Data.ByteString as BS
 import Data.ByteString.Internal (w2c)
 import qualified Data.ByteString.Lazy as LBS
 import Data.Data (Proxy (..))
@@ -133,6 +134,7 @@ import qualified Data.Text as Text
 import Data.Text.Encoding (decodeUtf8)
 import qualified Data.Text.IO as Text
 import Data.Time (DiffTime, diffTimeToPicoseconds, secondsToDiffTime)
+import Debug.Trace
 import GHC.Conc (ThreadStatus (..), threadStatus)
 import Hpgsql.Base
 import qualified Hpgsql.Builder as Builder
@@ -506,7 +508,7 @@ receiveNextMsgWithMaskedContinuation conn parser f =
     Left (msgIdentChar, mPgError) -> throw IrrecoverableHpgsqlError {hpgsqlDetails = "Could not parse postgres message with ident char " <> Text.pack (show msgIdentChar) <> ". This is an internal error in Hpgsql. Please report it.", innerException = toException <$> mPgError, relatedStatement = Nothing}
 
 data ReceiveWhat a b where
-  ReceiveDataRows :: ReceiveWhat DataRow (Maybe DataRow)
+  ReceiveDataRows :: ReceiveWhat DataRow [DataRow]
   ReceiveArbitraryMsg :: PgMsgParser a -> (Either (Char, Maybe PostgresError) a -> STM b) -> ReceiveWhat a b
 
 -- | Masks asynchronous exceptions in between the moment the message is extracted from
@@ -544,7 +546,7 @@ receiveNextMsgGeneric conn@HPgConnection {socket, recvBuffer} receiveWhat = do
     Just res -> pure res
   where
     modifyIORefIO ioref io = do
-      (newC, v) <- io
+      (!newC, !v) <- io
       atomicWriteIORef ioref newC
       pure v
     -- We mask_ because if the supplied STM action runs with a message extracted from
@@ -552,6 +554,7 @@ receiveNextMsgGeneric conn@HPgConnection {socket, recvBuffer} receiveWhat = do
     -- Ideally we'd have non-retriable STM at the type-level here. Maybe later.
     -- Make sure to do very little work inside `go`!
     go msgIdentChar restOfMsg fullMessageLen nowBuf = mask_ $ modifyIORefIO recvBuffer $ do
+      -- TODO: No bang annotation here?
       let !bufferWithoutMsg = LBS.drop fullMessageLen nowBuf
       let handleUnknownMessage onError =
             -- This could be a Notification, NOTICE or a ParameterStatus message, since these
@@ -582,17 +585,27 @@ receiveNextMsgGeneric conn@HPgConnection {socket, recvBuffer} receiveWhat = do
                 fmap (nowBuf,) $ Just <$> STM.atomically (onError (msgIdentChar, mPgError))
       case receiveWhat of
         ReceiveDataRows ->
-          case parsePgMessage msgIdentChar restOfMsg (msgParser @DataRow) of
-            Just msg -> do
-              debugPrint $ "Received " ++ show msg
-              pure (bufferWithoutMsg, Just (Just msg))
-            Nothing -> handleUnknownMessage $ const $ pure Nothing -- No error when we stop receiving a DataRow, only a Nothing
+          case Parser.parseOnly (Parser.matchLeftUnconsumed (Parser.parseMany customDataRowParser)) (LBS.toStrict nowBuf) of
+            Parser.ParseOk (unconsumedBuffer, msgs@(_ : _)) -> do
+              debugPrint $ "Received " ++ show msgs
+              pure (LBS.fromStrict unconsumedBuffer, Just msgs)
+            _ -> handleUnknownMessage $ const $ pure [] -- No error when we stop receiving DataRows, only emptiness
         ReceiveArbitraryMsg parser f ->
           case parsePgMessage msgIdentChar restOfMsg parser of
             Just msg -> do
               debugPrint $ "Received " ++ show msg
               fmap (bufferWithoutMsg,) $ Just <$> STM.atomically (f (Right msg))
             Nothing -> handleUnknownMessage (f . Left)
+
+    customDataRowParser = do
+      charAndLength <- Parser.take 5
+      let (w2c -> msgIdentChar, lenbs) = fromMaybe (error "impossible") $ BS.uncons charAndLength
+          lenLeftToFetch :: Int = fromIntegral $ either error id (Cereal.decode @Int32 lenbs) - 4
+      if msgIdentChar == 'D'
+        then do
+          rowColumnData <- BS.drop 2 <$> Parser.take lenLeftToFetch
+          pure $ DataRow rowColumnData
+        else fail "Not a DataRow"
 
     -- \| Appends into the internal buffer by reading from the socket
     -- until the buffer has at least N bytes.
@@ -883,24 +896,25 @@ consumeResults conn qryId = do
       pure (mERowDesc, pure $ Right cmd)
     (mERowDesc, Middle3 mDataRow) -> do
       let allOtherRows =
-            S.unfold
-              ( \() -> do
-                  mRow <- receiveNextMsgGeneric conn ReceiveDataRows
-                  case mRow of
-                    Just row -> pure $ Right (row :> ())
-                    Nothing -> do
-                      stateAfterNextMsg <- snd <$> receiveOutstandingResponseMsgsAtomically thisThreadId conn qryId
-                      case stateAfterNextMsg of
-                        ErrorResponseReceived _ err -> do
-                          receiveReadyForQueryIfNecessary thisThreadId
-                          pure $ Left $ Left err
-                        CommandCompleteReceived _ cmd -> do
-                          receiveReadyForQueryIfNecessary thisThreadId
-                          pure $ Left $ Right cmd
-                        ReadyForQueryReceived errOrCmd _ -> pure $ Left errOrCmd
-                        _ -> throwIrrecoverableError "Internal error in Hpgsql. After a DataRow we should get either an ErrorResponse or a CommandComplete message"
-              )
-              ()
+            S.concat $
+              S.unfold
+                ( \() -> do
+                    mRow <- receiveNextMsgGeneric conn ReceiveDataRows
+                    case mRow of
+                      rows@(_ : _) -> pure $ Right (rows :> ())
+                      [] -> do
+                        stateAfterNextMsg <- snd <$> receiveOutstandingResponseMsgsAtomically thisThreadId conn qryId
+                        case stateAfterNextMsg of
+                          ErrorResponseReceived _ err -> do
+                            receiveReadyForQueryIfNecessary thisThreadId
+                            pure $ Left $ Left err
+                          CommandCompleteReceived _ cmd -> do
+                            receiveReadyForQueryIfNecessary thisThreadId
+                            pure $ Left $ Right cmd
+                          ReadyForQueryReceived errOrCmd _ -> pure $ Left errOrCmd
+                          st -> throwIrrecoverableError $ "Internal error in Hpgsql. After the last DataRow we should get either an ErrorResponse or a CommandComplete message. State: " <> Text.pack (show st)
+                )
+                ()
           finalStream = case mDataRow of
             Nothing -> allOtherRows
             Just dr ->

--- a/hpgsql/src/Hpgsql/Internal.hs
+++ b/hpgsql/src/Hpgsql/Internal.hs
@@ -955,6 +955,9 @@ consumeResultsIgnoreRows conn qryId = do
     Right (CommandComplete n) -> pure n
 
 -- | Runs a query and streams results directly from the connection's socket, i.e. without using cursors.
+-- Once you assign the returned Stream to a binding, you must consume that binding linearly, i.e.
+-- you should never consume it more than once, for it _will_ give you wrong results if you do that.
+-- This is normal behaviour for IO Streams, but it's worth emphasizing.
 --
 -- Note on thread safety: it is important to note the same thread that runs this must
 -- be the thread that consumes the returned Stream, and the returned Stream must be
@@ -964,6 +967,9 @@ queryS :: (FromPgRow a) => HPgConnection -> Query -> IO (Stream (Of a) IO ())
 queryS = querySWith rowDecoder
 
 -- | Runs a query and streams results directly from the connection's socket, i.e. without using cursors.
+-- Once you assign the returned Stream to a binding, you must consume that binding linearly, i.e.
+-- you should never consume it more than once, for it _will_ give you wrong results if you do that.
+-- This is normal behaviour for IO Streams, but it's worth emphasizing.
 --
 -- Note on thread safety: it is important to note the same thread that runs this must
 -- be the thread that consumes the returned Stream, and the returned Stream must be
@@ -976,6 +982,10 @@ querySWith rparser conn qry = join $ runPipeline conn $ pipelineSWith rparser qr
 --
 -- Prefer to use 'queryS' and 'querySWith', because 'RowDecoder' can typecheck PostgreSQL results
 -- even when no rows are returned by queries, and 'RowDecoderMonadic' cannot.
+--
+-- Once you assign the returned Stream to a binding, you must consume that binding linearly, i.e.
+-- you should never consume it more than once, for it _will_ give you wrong results if you do that.
+-- This is normal behaviour for IO Streams, but it's worth emphasizing.
 --
 -- Note on thread safety: it is important to note the same thread that runs this must
 -- be the thread that consumes the returned Stream, and the returned Stream must be
@@ -1227,10 +1237,16 @@ acquireOwnershipOfOrphanedQueries conn = do
         Just tid -> (`elem` [ThreadDied, ThreadFinished]) <$> threadStatus tid
 
 -- | Fetches any number of rows by streaming them directly from the socket.
+-- Once you assign the returned Stream to a binding, you must consume that binding linearly, i.e.
+-- you should never consume it more than once, for it _will_ give you wrong results if you do that.
+-- This is normal behaviour for IO Streams, but it's worth emphasizing.
 pipelineS :: (FromPgRow a) => Query -> Pipeline (IO (Stream (Of a) IO ()))
 pipelineS = pipelineSWith rowDecoder
 
 -- | Fetches any number of rows by streaming them directly from the socket, with a custom row decoder.
+-- Once you assign the returned Stream to a binding, you must consume that binding linearly, i.e.
+-- you should never consume it more than once, for it _will_ give you wrong results if you do that.
+-- This is normal behaviour for IO Streams, but it's worth emphasizing.
 pipelineSWith :: RowDecoder a -> Query -> Pipeline (IO (Stream (Of a) IO ()))
 pipelineSWith rowparser@(RowDecoder _ _ expectedColFmts) (lastAndInitNE . breakQueryIntoStatements -> (firstQueriesToSend, lastQueryToSend)) =
   Pipeline
@@ -1244,6 +1260,9 @@ pipelineSWith rowparser@(RowDecoder _ _ expectedColFmts) (lastAndInitNE . breakQ
 
 -- | Prefer to use 'pipelineS' and 'pipelineSWith', because 'RowDecoder' can typecheck PostgreSQL results
 -- even when no rows are returned by queries, and 'RowDecoderMonadic' cannot.
+-- Once you assign the returned Stream to a binding, you must consume that binding linearly, i.e.
+-- you should never consume it more than once, for it _will_ give you wrong results if you do that.
+-- This is normal behaviour for IO Streams, but it's worth emphasizing.
 pipelineSMWith :: RowDecoderMonadic a -> Query -> Pipeline (IO (Stream (Of a) IO ()))
 pipelineSMWith rowparser (lastAndInitNE . breakQueryIntoStatements -> (firstQueriesToSend, lastQueryToSend)) =
   Pipeline

--- a/hpgsql/src/Hpgsql/Internal.hs
+++ b/hpgsql/src/Hpgsql/Internal.hs
@@ -531,34 +531,28 @@ receiveNextMsgGeneric conn@HPgConnection {socket, recvBuffer} receiveWhat = do
   -- due to the presence of asynchronous exceptions.
   -- So we append to the buffer up until it has been fully fetched,
   -- and then extract it from the buffer in one piece.
-  currentBuf <- receiveUntilBufferHasAtLeast 5
-  let bufLen = LBS.length currentBuf
-  let charAndLength = LBS.take 5 currentBuf
+  (initialBuf, initialBufLen) <- receiveUntilBufferHasAtLeast 5
+  let charAndLength = LBS.take 5 initialBuf
   let (w2c -> msgIdentChar, lenbs) = fromMaybe (error "impossible") $ LBS.uncons charAndLength
       lenLeftToFetch :: Int64 = fromIntegral $ either error id (Cereal.decodeLazy @Int32 lenbs) - 4
       fullMessageLen = 5 + lenLeftToFetch
-  restOfMsg <- LBS.drop 5 . LBS.take fullMessageLen <$> if bufLen >= fullMessageLen then pure currentBuf else receiveUntilBufferHasAtLeast fullMessageLen
-  receivedNoticeOrParameterSoTryAgain <- go msgIdentChar restOfMsg fullMessageLen
+  (nowBuf, _nowBufLen) <- if initialBufLen >= fullMessageLen then pure (initialBuf, initialBufLen) else receiveUntilBufferHasAtLeast fullMessageLen
+  let restOfMsg = LBS.drop 5 $ LBS.take fullMessageLen nowBuf
+  receivedNoticeOrParameterSoTryAgain <- go msgIdentChar restOfMsg fullMessageLen nowBuf
   case receivedNoticeOrParameterSoTryAgain of
     Nothing -> receiveNextMsgGeneric conn receiveWhat
     Just res -> pure res
   where
     modifyIORefIO ioref io = do
-      c <- readIORef ioref
-      (newC, v) <- io c
+      (newC, v) <- io
       atomicWriteIORef ioref newC
       pure v
     -- We mask_ because if the supplied STM action runs with a message extracted from
     -- the recvBuffer, then we _must_ remove that message from recvBuffer.
     -- Ideally we'd have non-retriable STM at the type-level here. Maybe later.
     -- Make sure to do very little work inside `go`!
-    go msgIdentChar restOfMsg fullMessageLen = mask_ $ modifyIORefIO recvBuffer $ \lbs -> do
-      let !bufferWithoutMsg =
-            if LBS.length lbs >= fullMessageLen
-              then LBS.drop fullMessageLen lbs
-              else
-                error "Bug in Hpgsql. Internal buffer's bytes weren't filled enough"
-
+    go msgIdentChar restOfMsg fullMessageLen nowBuf = mask_ $ modifyIORefIO recvBuffer $ do
+      let !bufferWithoutMsg = LBS.drop fullMessageLen nowBuf
       let handleUnknownMessage onError =
             -- This could be a Notification, NOTICE or a ParameterStatus message, since these
             -- can be received _at any time_ according to the docs.
@@ -585,7 +579,7 @@ receiveNextMsgGeneric conn@HPgConnection {socket, recvBuffer} receiveWhat = do
                 -- Just in case this is a postgres error, it might include useful information,
                 -- so we spit that out
                 let mPgError = mkPostgresError "" <$> parsePgMessage msgIdentChar restOfMsg (msgParser @ErrorResponse)
-                fmap (lbs,) $ Just <$> STM.atomically (onError (msgIdentChar, mPgError))
+                fmap (nowBuf,) $ Just <$> STM.atomically (onError (msgIdentChar, mPgError))
       case receiveWhat of
         ReceiveDataRows ->
           case parsePgMessage msgIdentChar restOfMsg (msgParser @DataRow) of
@@ -602,13 +596,13 @@ receiveNextMsgGeneric conn@HPgConnection {socket, recvBuffer} receiveWhat = do
 
     -- \| Appends into the internal buffer by reading from the socket
     -- until the buffer has at least N bytes.
-    -- Returns the current buffer.
-    receiveUntilBufferHasAtLeast :: Int64 -> IO LBS.ByteString
+    -- Returns the current buffer and its length.
+    receiveUntilBufferHasAtLeast :: Int64 -> IO (LBS.ByteString, Int64)
     receiveUntilBufferHasAtLeast minBytesNecessary = do
       currentBuffer <- readIORef recvBuffer
       let nBytesInBuffer = LBS.length currentBuffer
       if nBytesInBuffer >= minBytesNecessary
-        then pure currentBuffer
+        then pure (currentBuffer, nBytesInBuffer)
         else do
           -- This takes from the kernel's recv buffer and appends to our buffer atomically,
           -- or an exception is thrown when receiving.

--- a/hpgsql/src/Hpgsql/Internal.hs
+++ b/hpgsql/src/Hpgsql/Internal.hs
@@ -553,7 +553,7 @@ receiveNextMsgGeneric conn@HPgConnection {socket, recvBuffer} receiveWhat = do
     -- Make sure to do very little work inside `go`!
     go msgIdentChar restOfMsg fullMessageLen nowBuf = mask_ $ modifyIORefIO recvBuffer $ do
       let bufferWithoutMsg = LBS.drop fullMessageLen nowBuf
-          handleUnknownMessage onError =
+          handleUnexpectedMsg onNotAnyReasonableMsg =
             -- This could be a Notification, NOTICE or a ParameterStatus message, since these
             -- can be received _at any time_ according to the docs.
             case parsePgMessage msgIdentChar restOfMsg (Left3 <$> msgParser @NotificationResponse <|> Middle3 <$> msgParser @NoticeResponse <|> Right3 <$> msgParser @ParameterStatus) of
@@ -579,7 +579,7 @@ receiveNextMsgGeneric conn@HPgConnection {socket, recvBuffer} receiveWhat = do
                 -- Just in case this is a postgres error, it might include useful information,
                 -- so we spit that out
                 let mPgError = mkPostgresError "" <$> parsePgMessage msgIdentChar restOfMsg (msgParser @ErrorResponse)
-                fmap (nowBuf,) $ Just <$> STM.atomically (onError (msgIdentChar, mPgError))
+                fmap (nowBuf,) $ Just <$> STM.atomically (onNotAnyReasonableMsg (msgIdentChar, mPgError))
       case receiveWhat of
         ReceiveDataRows ->
           -- Parse as many DataRows as we can to do as much work as we can per buffer "churn"
@@ -587,14 +587,17 @@ receiveNextMsgGeneric conn@HPgConnection {socket, recvBuffer} receiveWhat = do
             Parser.ParseOk (unconsumedBuffer, msgs@(_ : _)) -> do
               debugPrint $ "Received " ++ show msgs
               pure (LBS.fromStrict unconsumedBuffer, Just msgs)
-            _ -> handleUnknownMessage $ const $ pure [] -- No error when we stop receiving DataRows, only emptiness
+            _ -> handleUnexpectedMsg $ const $ pure [] -- No error when we stop receiving DataRows, only emptiness
         ReceiveArbitraryMsg parser f ->
           case parsePgMessage msgIdentChar restOfMsg parser of
             Just msg -> do
               debugPrint $ "Received " ++ show msg
               fmap (bufferWithoutMsg,) $ Just <$> STM.atomically (f (Right msg))
-            Nothing -> handleUnknownMessage (f . Left)
+            Nothing -> handleUnexpectedMsg (f . Left)
 
+    -- Sadly we have to repeat the parsing of a DataRow message here, when it already
+    -- exists in the FromPgMessage instance and in the body of this function. Maybe
+    -- we can improve this later.
     customDataRowParser = do
       charAndLength <- Parser.take 5
       let (w2c -> msgIdentChar, lenbs) = fromMaybe (error "impossible") $ BS.uncons charAndLength

--- a/hpgsql/src/Hpgsql/Internal.hs
+++ b/hpgsql/src/Hpgsql/Internal.hs
@@ -134,7 +134,6 @@ import qualified Data.Text as Text
 import Data.Text.Encoding (decodeUtf8)
 import qualified Data.Text.IO as Text
 import Data.Time (DiffTime, diffTimeToPicoseconds, secondsToDiffTime)
-import Debug.Trace
 import GHC.Conc (ThreadStatus (..), threadStatus)
 import Hpgsql.Base
 import qualified Hpgsql.Builder as Builder
@@ -155,7 +154,6 @@ import qualified Network.Socket.ByteString as SocketBS
 import qualified Network.Socket.ByteString.Lazy as SocketLBS
 import Streaming (Of (..), Stream)
 import qualified Streaming as S
-import qualified Streaming.Internal as SInternal
 import qualified Streaming.Prelude as S
 import System.IO (stderr)
 import System.IO.Error (isResourceVanishedError)
@@ -554,9 +552,8 @@ receiveNextMsgGeneric conn@HPgConnection {socket, recvBuffer} receiveWhat = do
     -- Ideally we'd have non-retriable STM at the type-level here. Maybe later.
     -- Make sure to do very little work inside `go`!
     go msgIdentChar restOfMsg fullMessageLen nowBuf = mask_ $ modifyIORefIO recvBuffer $ do
-      -- TODO: No bang annotation here?
-      let !bufferWithoutMsg = LBS.drop fullMessageLen nowBuf
-      let handleUnknownMessage onError =
+      let bufferWithoutMsg = LBS.drop fullMessageLen nowBuf
+          handleUnknownMessage onError =
             -- This could be a Notification, NOTICE or a ParameterStatus message, since these
             -- can be received _at any time_ according to the docs.
             case parsePgMessage msgIdentChar restOfMsg (Left3 <$> msgParser @NotificationResponse <|> Middle3 <$> msgParser @NoticeResponse <|> Right3 <$> msgParser @ParameterStatus) of
@@ -585,6 +582,7 @@ receiveNextMsgGeneric conn@HPgConnection {socket, recvBuffer} receiveWhat = do
                 fmap (nowBuf,) $ Just <$> STM.atomically (onError (msgIdentChar, mPgError))
       case receiveWhat of
         ReceiveDataRows ->
+          -- Parse as many DataRows as we can to do as much work as we can per buffer "churn"
           case Parser.parseOnly (Parser.matchLeftUnconsumed (Parser.parseMany customDataRowParser)) (LBS.toStrict nowBuf) of
             Parser.ParseOk (unconsumedBuffer, msgs@(_ : _)) -> do
               debugPrint $ "Received " ++ show msgs
@@ -918,8 +916,7 @@ consumeResults conn qryId = do
           finalStream = case mDataRow of
             Nothing -> allOtherRows
             Just dr ->
-              SInternal.Step $
-                dr :> allOtherRows
+              dr `S.cons` allOtherRows
       pure (mERowDesc, finalStream)
   where
     receiveReadyForQueryIfNecessary :: WeakThreadId -> IO ()

--- a/hpgsql/src/Hpgsql/SimpleParser.hs
+++ b/hpgsql/src/Hpgsql/SimpleParser.hs
@@ -12,6 +12,9 @@ module Hpgsql.SimpleParser
     take,
     endOfInput,
     match,
+    parseMany,
+    matchLen,
+    matchLeftUnconsumed,
   )
 where
 
@@ -32,7 +35,7 @@ newtype Parser a = Parser
       (String -> r) ->
       -- \^ failure continuation
       (a -> ByteString -> r) ->
-      -- \^ success continuation
+      -- \^ success continuation, taking left-unparsed ByteString and parsed value
       r
   }
 
@@ -85,6 +88,14 @@ take n = Parser $ \bs kf ks ->
       ks mempty bs
 {-# INLINE take #-}
 
+parseMany :: Parser a -> Parser [a]
+parseMany p = Parser $ \bs' _kf ks -> let (vs, rest) = go bs' in ks vs rest
+  where
+    go bs = case parseOnly (matchLeftUnconsumed p) bs of
+      ParseOk (unconsumed, v) -> let (vs, rest) = go unconsumed in (v : vs, rest)
+      ParseFail _ -> ([], bs)
+{-# INLINE parseMany #-}
+
 -- | Succeeds only when the input has been fully consumed.
 endOfInput :: Parser ()
 endOfInput = Parser $ \bs kf ks ->
@@ -104,3 +115,26 @@ match (Parser p) = Parser $ \bs kf ks ->
          in ks (consumed, a) bs'
     )
 {-# INLINE match #-}
+
+-- | Run a parser and additionally return the length of the slice of input it consumed.
+matchLen :: Parser a -> Parser (Int, a)
+matchLen (Parser p) = Parser $ \bs kf ks ->
+  p
+    bs
+    kf
+    ( \a bs' ->
+        let !consumed = BS.length bs - BS.length bs'
+         in ks (consumed, a) bs'
+    )
+{-# INLINE matchLen #-}
+
+-- | Run a parser and additionally return the unconsumed/unparsed ByteString.
+matchLeftUnconsumed :: Parser a -> Parser (ByteString, a)
+matchLeftUnconsumed (Parser p) = Parser $ \bs kf ks ->
+  p
+    bs
+    kf
+    ( \a bs' ->
+        ks (bs', a) bs'
+    )
+{-# INLINE matchLeftUnconsumed #-}

--- a/hpgsql/src/Hpgsql/SimpleParser.hs
+++ b/hpgsql/src/Hpgsql/SimpleParser.hs
@@ -13,7 +13,6 @@ module Hpgsql.SimpleParser
     endOfInput,
     match,
     parseMany,
-    matchLen,
     matchLeftUnconsumed,
   )
 where
@@ -115,18 +114,6 @@ match (Parser p) = Parser $ \bs kf ks ->
          in ks (consumed, a) bs'
     )
 {-# INLINE match #-}
-
--- | Run a parser and additionally return the length of the slice of input it consumed.
-matchLen :: Parser a -> Parser (Int, a)
-matchLen (Parser p) = Parser $ \bs kf ks ->
-  p
-    bs
-    kf
-    ( \a bs' ->
-        let !consumed = BS.length bs - BS.length bs'
-         in ks (consumed, a) bs'
-    )
-{-# INLINE matchLen #-}
 
 -- | Run a parser and additionally return the unconsumed/unparsed ByteString.
 matchLeftUnconsumed :: Parser a -> Parser (ByteString, a)


### PR DESCRIPTION
I'm seeing a ~15.4% reduction in run time materializing rows with this change.

The main change is once we extract from the IORef buffer, we now parse as many DataRows at once as we can, instead of parsing at most one DataRow per buffer access.

max_mem_in_use_bytes does go up a few MB in some benchmarks because of course we materialize more rows at once - but that's still a very worthy tradeoff.