### PR TITLE
Force SOCK_STREAM in getAddrInfo hints to fix macOS/BSD connect bug

### DIFF
--- a/hpgsql/src/Hpgsql/Internal.hs
+++ b/hpgsql/src/Hpgsql/Internal.hs
@@ -367,7 +367,7 @@ internalConnectOrCancel connectOrCancel connOpts originalConnStr@ConnectionStrin
                     addrCanonName = Nothing
                   }
             else do
-              addrInfos <- Socket.getAddrInfo (Just Socket.defaultHints) (Just $ Text.unpack hostname) (Just $ show port)
+              addrInfos <- Socket.getAddrInfo (Just Socket.defaultHints {Socket.addrSocketType = Socket.Stream}) (Just $ Text.unpack hostname) (Just $ show port)
               case addrInfos of
                 [] -> throwIrrecoverableError "Could not resolve address"
                 addrInfo : _ -> pure addrInfo


### PR DESCRIPTION
Socket.defaultHints leaves addrSocketType as NoSocketType, so getaddrinfo() is free to return entries in any order for the requested host/port. On macOS this can return a SOCK_DGRAM (UDP) entry before the SOCK_STREAM (TCP) one for the same loopback host/port; internalConnectOrCancel takes the first result unconditionally, so hpgsql ends up opening a UDP socket to Postgres.

connect()/send() on that UDP socket "succeed" (UDP has no handshake), so the startup message appears to be sent successfully. The failure only surfaces on the first recv(), as ECONNREFUSED from an ICMP port-unreachable reply, since nothing is listening on that UDP port. Postgres never sees any connection attempt when this happens.

Explicitly requesting addrSocketType = Stream removes the UDP entries from getAddrInfo's results.

This fixes issue #28 