### PR TITLE
Test TCP connections in CI too

### DIFF
--- a/.env
+++ b/.env
@@ -1,5 +1,5 @@
 PGPORT=5432
-PGHOST=127.0.0.1
+PGHOST=/tmp
 PGDATABASE=hpgsql
 PGUSER=postgres
 PGSUPERUSER=postgres

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,6 +16,7 @@ defaults:
 
 env:
   HPGSQL_THREADED: +threaded
+  PGHOST: /tmp
 
 jobs:
   build-x86_64-linux:
@@ -49,6 +50,7 @@ jobs:
         # to many things, and our library relies on a lot of ThreadId tracking,
         # interruption safety, MVars and STM, so we test the single threaded
         # runtime, too.
+        # We also vary things like PGHOST to test both TCP and Unix Domain Sockets.
         concurrently -g --timings --names pg18,pg17,pg16,pg15,pg14,single-threaded-rts,ghc984,ghc967 \
           'timeout 5m scripts/ci/run-tests-and-annotate-with-error.sh local/pg18-tests.txt nix-build --no-out-link -A testsPg18' \
           'timeout 5m scripts/ci/run-tests-and-annotate-with-error.sh local/pg17-tests.txt nix-build --no-out-link -A testsPg17' \
@@ -56,7 +58,7 @@ jobs:
           'timeout 5m scripts/ci/run-tests-and-annotate-with-error.sh local/pg15-tests.txt nix-build --no-out-link -A testsPg15' \
           'timeout 5m scripts/ci/run-tests-and-annotate-with-error.sh local/pg14-tests.txt nix-build --no-out-link -A testsPg14' \
           'nix-build --no-out-link --argstr threading "-threaded" -A hpgsql-tests && timeout 5m scripts/ci/run-tests-and-annotate-with-error.sh local/pg18-single-threaded-rts-tests.txt nix-build --no-out-link --argstr threading "-threaded" -A testsPg18' \
-          'nix-build --no-out-link --argstr ghc ghc984 -A hpgsql-tests && timeout 5m scripts/ci/run-tests-and-annotate-with-error.sh local/pg18-ghc984-tests.txt nix-build --no-out-link --argstr ghc ghc984 -A testsPg18' \
+          'nix-build --no-out-link --argstr ghc ghc984 --argstr PGHOST localhost -A hpgsql-tests && timeout 5m scripts/ci/run-tests-and-annotate-with-error.sh local/pg18-ghc984-tests.txt nix-build --no-out-link --argstr ghc ghc984 -A testsPg18' \
           'nix-build --no-out-link --argstr ghc ghc967 -A hpgsql-tests && timeout 5m scripts/ci/run-tests-and-annotate-with-error.sh local/pg18-ghc967-tests.txt nix-build --no-out-link --argstr ghc ghc967 -A testsPg18'
 
     - name: Run hpgsql-simple-compat tests
@@ -113,8 +115,9 @@ jobs:
         # to many things, and our library relies on a lot of ThreadId tracking,
         # interruption safety, MVars and STM, so we test the single threaded
         # runtime, too.
+        # We also vary things like PGHOST to test both TCP and Unix Domain Sockets.
         nix-build --no-out-link --argstr threading "-threaded" -A hpgsql-tests
-        timeout 5m scripts/ci/run-tests-and-annotate-with-error.sh local/pg18-single-threaded-rts-tests.txt nix-build --no-out-link --argstr threading "-threaded" -A testsPg18
+        timeout 5m scripts/ci/run-tests-and-annotate-with-error.sh local/pg18-single-threaded-rts-tests.txt nix-build --no-out-link --argstr threading "-threaded" --argstr PGHOST localhost -A testsPg18
 
     - name: Run hpgsql-simple-compat tests
       run: |

--- a/default.nix
+++ b/default.nix
@@ -2,6 +2,7 @@
     system ? builtins.currentSystem
   , threading ? builtins.getEnv "HPGSQL_THREADED"
   , ghc ? "ghc9103"
+  , PGHOST ? builtins.getEnv "PGHOST"
   , pkgs ? import ./nix/nixpkgs.nix { inherit system threading; }
 }:
 let
@@ -18,22 +19,22 @@ rec {
   hpgsql-benchmarks = haskellPackages.hpgsql-benchmarks;
   inherit haskellPackages;
 
-  hpgsqlSimpleCompatTestsPg18 = { hspecArgs ? ""}: import ./nix/run-hpgsql-simple-compat-db-tests.nix { inherit pkgs hpgsql-simple-compat-tests hspecArgs; postgres = addPgExtensions pkgs.postgresql_18; };
-  hpgsqlSimpleCompatTestsPg17 = { hspecArgs ? ""}: import ./nix/run-hpgsql-simple-compat-db-tests.nix { inherit pkgs hpgsql-simple-compat-tests hspecArgs; postgres = addPgExtensions pkgs.postgresql_17; };
-  hpgsqlSimpleCompatTestsPg16 = { hspecArgs ? ""}: import ./nix/run-hpgsql-simple-compat-db-tests.nix { inherit pkgs hpgsql-simple-compat-tests hspecArgs; postgres = addPgExtensions pkgs.postgresql_16; };
-  hpgsqlSimpleCompatTestsPg15 = { hspecArgs ? ""}: import ./nix/run-hpgsql-simple-compat-db-tests.nix { inherit pkgs hpgsql-simple-compat-tests hspecArgs; postgres = addPgExtensions pkgs.postgresql_15; };
-  hpgsqlSimpleCompatTestsPg14 = { hspecArgs ? ""}: import ./nix/run-hpgsql-simple-compat-db-tests.nix { inherit pkgs hpgsql-simple-compat-tests hspecArgs; postgres = addPgExtensions pkgs.postgresql_14; };
-  testsPg18 = { hspecArgs ? ""}: import ./nix/run-db-tests.nix { inherit pkgs hpgsql-tests hspecArgs; postgres = addPgExtensions pkgs.postgresql_18; };
-  testsPg17 = { hspecArgs ? ""}: import ./nix/run-db-tests.nix { inherit pkgs hpgsql-tests hspecArgs; postgres = addPgExtensions pkgs.postgresql_17; };
-  testsPg16 = { hspecArgs ? ""}: import ./nix/run-db-tests.nix { inherit pkgs hpgsql-tests hspecArgs; postgres = addPgExtensions pkgs.postgresql_16; };
-  testsPg15 = { hspecArgs ? ""}: import ./nix/run-db-tests.nix { inherit pkgs hpgsql-tests hspecArgs; postgres = addPgExtensions pkgs.postgresql_15; };
-  testsPg14 = { hspecArgs ? ""}: import ./nix/run-db-tests.nix { inherit pkgs hpgsql-tests hspecArgs; postgres = addPgExtensions pkgs.postgresql_14; };
+  hpgsqlSimpleCompatTestsPg18 = { hspecArgs ? ""}: import ./nix/run-hpgsql-simple-compat-db-tests.nix { inherit pkgs hpgsql-simple-compat-tests hspecArgs PGHOST; postgres = addPgExtensions pkgs.postgresql_18; };
+  hpgsqlSimpleCompatTestsPg17 = { hspecArgs ? ""}: import ./nix/run-hpgsql-simple-compat-db-tests.nix { inherit pkgs hpgsql-simple-compat-tests hspecArgs PGHOST; postgres = addPgExtensions pkgs.postgresql_17; };
+  hpgsqlSimpleCompatTestsPg16 = { hspecArgs ? ""}: import ./nix/run-hpgsql-simple-compat-db-tests.nix { inherit pkgs hpgsql-simple-compat-tests hspecArgs PGHOST; postgres = addPgExtensions pkgs.postgresql_16; };
+  hpgsqlSimpleCompatTestsPg15 = { hspecArgs ? ""}: import ./nix/run-hpgsql-simple-compat-db-tests.nix { inherit pkgs hpgsql-simple-compat-tests hspecArgs PGHOST; postgres = addPgExtensions pkgs.postgresql_15; };
+  hpgsqlSimpleCompatTestsPg14 = { hspecArgs ? ""}: import ./nix/run-hpgsql-simple-compat-db-tests.nix { inherit pkgs hpgsql-simple-compat-tests hspecArgs PGHOST; postgres = addPgExtensions pkgs.postgresql_14; };
+  testsPg18 = { hspecArgs ? ""}: import ./nix/run-db-tests.nix { inherit pkgs hpgsql-tests hspecArgs PGHOST; postgres = addPgExtensions pkgs.postgresql_18; };
+  testsPg17 = { hspecArgs ? ""}: import ./nix/run-db-tests.nix { inherit pkgs hpgsql-tests hspecArgs PGHOST; postgres = addPgExtensions pkgs.postgresql_17; };
+  testsPg16 = { hspecArgs ? ""}: import ./nix/run-db-tests.nix { inherit pkgs hpgsql-tests hspecArgs PGHOST; postgres = addPgExtensions pkgs.postgresql_16; };
+  testsPg15 = { hspecArgs ? ""}: import ./nix/run-db-tests.nix { inherit pkgs hpgsql-tests hspecArgs PGHOST; postgres = addPgExtensions pkgs.postgresql_15; };
+  testsPg14 = { hspecArgs ? ""}: import ./nix/run-db-tests.nix { inherit pkgs hpgsql-tests hspecArgs PGHOST; postgres = addPgExtensions pkgs.postgresql_14; };
 
   # Shells with specific-versioned postgres servers to run tests locally
-  shellPg18 = import ./nix/test-shell-pg.nix { inherit pkgs; postgres = addPgExtensions pkgs.postgresql_18; };
-  shellPg17 = import ./nix/test-shell-pg.nix { inherit pkgs; postgres = addPgExtensions pkgs.postgresql_17; };
-  shellPg16 = import ./nix/test-shell-pg.nix { inherit pkgs; postgres = addPgExtensions pkgs.postgresql_16; };
-  shellPg15 = import ./nix/test-shell-pg.nix { inherit pkgs; postgres = addPgExtensions pkgs.postgresql_15; };
-  shellPg14 = import ./nix/test-shell-pg.nix { inherit pkgs; postgres = addPgExtensions pkgs.postgresql_14; };
+  shellPg18 = import ./nix/test-shell-pg.nix { inherit pkgs PGHOST; postgres = addPgExtensions pkgs.postgresql_18; };
+  shellPg17 = import ./nix/test-shell-pg.nix { inherit pkgs PGHOST; postgres = addPgExtensions pkgs.postgresql_17; };
+  shellPg16 = import ./nix/test-shell-pg.nix { inherit pkgs PGHOST; postgres = addPgExtensions pkgs.postgresql_16; };
+  shellPg15 = import ./nix/test-shell-pg.nix { inherit pkgs PGHOST; postgres = addPgExtensions pkgs.postgresql_15; };
+  shellPg14 = import ./nix/test-shell-pg.nix { inherit pkgs PGHOST; postgres = addPgExtensions pkgs.postgresql_14; };
 }
   

--- a/hpgsql/src/Hpgsql/Internal.hs
+++ b/hpgsql/src/Hpgsql/Internal.hs
@@ -367,7 +367,7 @@ internalConnectOrCancel connectOrCancel connOpts originalConnStr@ConnectionStrin
                     addrCanonName = Nothing
                   }
             else do
-              addrInfos <- Socket.getAddrInfo (Just Socket.defaultHints) (Just $ Text.unpack hostname) (Just $ show port)
+              addrInfos <- Socket.getAddrInfo (Just Socket.defaultHints {Socket.addrSocketType = Socket.Stream}) (Just $ Text.unpack hostname) (Just $ show port)
               case addrInfos of
                 [] -> throwIrrecoverableError "Could not resolve address"
                 addrInfo : _ -> pure addrInfo

--- a/hpgsql/src/Hpgsql/Internal.hs
+++ b/hpgsql/src/Hpgsql/Internal.hs
@@ -367,7 +367,7 @@ internalConnectOrCancel connectOrCancel connOpts originalConnStr@ConnectionStrin
                     addrCanonName = Nothing
                   }
             else do
-              addrInfos <- Socket.getAddrInfo (Just Socket.defaultHints {Socket.addrSocketType = Socket.Stream}) (Just $ Text.unpack hostname) (Just $ show port)
+              addrInfos <- Socket.getAddrInfo (Just Socket.defaultHints) (Just $ Text.unpack hostname) (Just $ show port)
               case addrInfos of
                 [] -> throwIrrecoverableError "Could not resolve address"
                 addrInfo : _ -> pure addrInfo

--- a/nix/run-db-tests.nix
+++ b/nix/run-db-tests.nix
@@ -1,4 +1,4 @@
-{ postgres, pkgs, hpgsql-tests, hspecArgs }:
+{ postgres, pkgs, hpgsql-tests, hspecArgs, PGHOST }:
 let fs = pkgs.lib.fileset;
 in
  pkgs.stdenv.mkDerivation {
@@ -16,7 +16,7 @@ in
       export PGDATA="local/temp-pg-data"
       export PGDATABASE="postgres"
       export PGPORT="5434"
-      export PGHOST="/tmp"
+      export PGHOST="${PGHOST}"
       export PGUSER="postgres"
       scripts/init-pg-cluster.sh ./conf/test-db
       trap "pg_ctl stop || true" EXIT ERR

--- a/nix/run-hpgsql-simple-compat-db-tests.nix
+++ b/nix/run-hpgsql-simple-compat-db-tests.nix
@@ -1,4 +1,4 @@
-{ postgres, pkgs, hpgsql-simple-compat-tests, hspecArgs }:
+{ postgres, pkgs, hpgsql-simple-compat-tests, hspecArgs, PGHOST }:
 let fs = pkgs.lib.fileset;
 in
  pkgs.stdenv.mkDerivation {
@@ -16,7 +16,7 @@ in
       export PGDATA="local/temp-pg-data"
       export PGDATABASE="postgres"
       export PGPORT="5434"
-      export PGHOST="/tmp"
+      export PGHOST="${PGHOST}"
       export PGUSER="postgres"
       export DATABASE_CONNSTRING="user=$PGUSER dbname=$PGDATABASE host=$PGHOST port=$PGPORT"
       scripts/init-pg-cluster.sh ./conf/test-db

--- a/nix/test-shell-pg.nix
+++ b/nix/test-shell-pg.nix
@@ -1,4 +1,4 @@
-{ pkgs, postgres }:
+{ pkgs, postgres, PGHOST }:
 pkgs.mkShell {
   buildInputs = [ postgres pkgs.coreutils pkgs.bash pkgs.glibcLocales pkgs.run ] ++ pkgs.lib.optionals pkgs.stdenv.isLinux [ pkgs.strace ];
   description = "Test shell with postgres available and initializing";
@@ -8,7 +8,7 @@ pkgs.mkShell {
     export PGDATA="$(mktemp -d)"
     export PGDATABASE="postgres"
     export PGPORT="5434"
-    export PGHOST="/tmp"
+    export PGHOST="${PGHOST}"
     export PGUSER="postgres"
     trap "pg_ctl stop" EXIT ERR
     scripts/init-pg-cluster.sh ./conf/test-db


### PR DESCRIPTION
Previously we only tested Unix Domain sockets in CI, but not TCP. Was I hoping I would be able to run Darwin tests in parallel, I wonder? Or did I run into the bug recently fixed by a contributor? Not sure. In any case, we don't run Darwin tests in parallel because different instances of postgres would compete to listen on the same port (no Nix sandboxing in Darwin), which would make them fail.

After [a recent PR](https://github.com/mzabani/hpgsql/pull/29), it became clear to me that we lack tests with TCP. So we need to test it in the pipeline as well (also because cancellation requests reuse the connected-to address, so this is not something that only matters as far as "connection is established, everything now behaves the same"!).

In fact, this reproduces the bug the PR above fixes, [namely the following error](https://github.com/mzabani/hpgsql/actions/runs/28620413096/job/84874449385?pr=31#step:9:1181):
```
       >   To rerun use: --match "/Transaction/Hpgsql.Transaction/withTransaction issues ROLLBACK when the inner action throws a synchronous exception/" --seed 736461944
       >
       >   TransactionSpec.hs:31:3: 
       >   105) Transaction.Hpgsql.Transaction withTransaction lets irrecoverable errors propagate
       >        uncaught exception: IrrecoverableHpgsqlError
       >        IrrecoverableHpgsqlError {hpgsqlDetails = "An inner exception was thrown", innerException = Just user error (Internal error in hpgsql's recvNonBlocking), relatedStatement = Nothing}
       >
       >   To rerun use: --match "/Transaction/Hpgsql.Transaction/withTransaction lets irrecoverable errors propagate/" --seed 736461944
```