### PR TITLE
Remove the transformers dependency

### DIFF
--- a/hpgsql/hpgsql.cabal
+++ b/hpgsql/hpgsql.cabal
@@ -114,7 +114,6 @@ library
     template-haskell >= 2.20 && < 2.24,
     text >= 2.0 && < 2.2,
     time >= 1.12 && < 1.15,
-    transformers >= 0.6 && < 0.7,
     uuid-types >= 1.0 && < 1.1,
     vector >= 0.13 && < 0.14
   default-language: Haskell2010

--- a/hpgsql/src/Hpgsql/Connection.hs
+++ b/hpgsql/src/Hpgsql/Connection.hs
@@ -27,7 +27,6 @@ import Control.Monad
     void,
     when,
   )
-import Control.Monad.Trans.Except (runExceptT, throwE)
 import Data.Attoparsec.Text
   ( Parser,
     char,
@@ -41,7 +40,6 @@ import qualified Data.Attoparsec.Text as Parsec
 import Data.ByteString (ByteString)
 import qualified Data.ByteString as ByteString
 import qualified Data.Char as Char
-import Data.Functor.Identity (Identity (..))
 import Data.List
   ( sortOn,
   )
@@ -115,17 +113,17 @@ eitherToMay (Right v) = Just v
 -- | Parses a URI with scheme 'postgres' or 'postgresql', as per https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING.
 -- The difference here is that URIs with a query string or with a fragment are not allowed.
 uriConnParser :: Text -> Either String ConnectionString
-uriConnParser line = runIdentity $ runExceptT @String @_ @ConnectionString $ do
+uriConnParser line =
   case parseURI (Text.unpack line) of
-    Nothing -> throwE "Connection string is not a URI"
+    Nothing -> Left "Connection string is not a URI"
     Just URI {..} -> do
       unless
         (Text.toLower (Text.pack uriScheme) `elem` ["postgres:", "postgresql:"])
-        $ throwE
+        $ Left
           "Connection string's URI scheme must be 'postgres' or 'postgresql'"
       case uriAuthority of
         Nothing ->
-          throwE
+          Left
             "Connection string must contain at least user and host"
         Just URIAuth {..} -> do
           let database =
@@ -133,10 +131,10 @@ uriConnParser line = runIdentity $ runExceptT @String @_ @ConnectionString $ do
               hasQueryString = not $ null uriQuery
               hasFragment = not $ null uriFragment
           when (Text.null database) $
-            throwE
+            Left
               "Connection string must contain a database name"
           when (hasQueryString || hasFragment) $
-            throwE
+            Left
               "Custom parameters are not supported in connection strings. Make sure your connection URI does not have a query string or query fragment"
 
           -- Ports are not mandatory and are defaulted to 5432 when not present
@@ -148,7 +146,7 @@ uriConnParser line = runIdentity $ runExceptT @String @_ @ConnectionString $ do
                   (Text.pack $ trimFirst ':' uriPort)
               ) of
             Nothing ->
-              throwE "Invalid port in connection string"
+              Left "Invalid port in connection string"
             Just parsedPort -> do
               let (Text.pack . unEscapeString . trimLast '@' -> user, Text.pack . unEscapeString . trimLast '@' . trimFirst ':' -> password) =
                     break (== ':') uriUserInfo
@@ -178,7 +176,7 @@ uriConnParser line = runIdentity $ runExceptT @String @_ @ConnectionString $ do
       Just (t, lastChar) -> if lastChar == c then Text.unpack t else s
 
 keywordValueConnParser :: Text -> Either String ConnectionString
-keywordValueConnParser line = runIdentity $ runExceptT $ do
+keywordValueConnParser line = do
   kvs <-
     sortOn fst
       <$> parseOrFail
@@ -196,7 +194,7 @@ keywordValueConnParser line = runIdentity $ runExceptT $ do
     getVal key def parser pairs =
       case (map snd $ filter ((== key) . fst) pairs, def) of
         ([], Nothing) ->
-          throwE $
+          Left $
             "Connection string must contain a value for '"
               <> Text.unpack key
               <> "'"
@@ -207,7 +205,7 @@ keywordValueConnParser line = runIdentity $ runExceptT $ do
               <> Text.unpack key
               <> "' is in an unrecognizable format"
         _ ->
-          throwE $
+          Left $
             "Duplicate key '"
               <> Text.unpack key
               <> "' found in connection string."
@@ -215,7 +213,7 @@ keywordValueConnParser line = runIdentity $ runExceptT $ do
     txtToString = Parsec.takeText
     parseOrFail parser txt errorMsg =
       case parseOnly (parser <* endOfInput) txt of
-        Left _ -> throwE errorMsg
+        Left _ -> Left errorMsg
         Right v -> pure v
 
     singleKeyVal = do

--- a/hpgsql/src/Hpgsql/Msgs.hs
+++ b/hpgsql/src/Hpgsql/Msgs.hs
@@ -1,8 +1,8 @@
 module Hpgsql.Msgs (AuthenticationResponse (..), AuthenticationMethod (..), BackendKeyData (..), Bind (..), BindComplete (..), CancelRequest (..), CommandComplete (..), CopyData (..), CopyDone (..), CopyFail (..), CopyInResponse (..), DataRow (..), Describe (..), ErrorDetail (..), ErrorResponse (..), Execute (..), Flush (..), NoData (..), ParameterStatus (..), Query (..), ReadyForQuery (..), RowDescription (..), SASLInitialResponse (..), SASLResponse (..), StartupMessage (..), ToPgMessage (..), FromPgMessage (..), PgMsgParser (..), Terminate (..), TransactionStatus (..), NoticeResponse (..), NotificationResponse (..), Parse (..), ParseComplete (..), PasswordMessage (..), Sync (..), parsePgMessage, nulTermCString) where
 
 import Control.Applicative (Alternative (..))
+import Control.Arrow (Kleisli (..))
 import Control.Monad (replicateM)
-import Control.Monad.Trans.Reader (ReaderT (..))
 import qualified Crypto.Hash as Crypto
 import qualified Data.Attoparsec.ByteString as Parsec
 import qualified Data.Attoparsec.ByteString.Lazy as LazyParsec
@@ -39,7 +39,9 @@ newtype PgMsgParser a
         Maybe a
       )
   deriving stock (Functor)
-  deriving (Applicative, Alternative) via (ReaderT Char (ReaderT LBS.ByteString Maybe))
+  -- Kleisli m a is a newtype over 'a -> m b', so two nested Kleislis are exactly
+  -- this parser's shape, and both instances lift pointwise into Maybe.
+  deriving (Applicative, Alternative) via (Kleisli (Kleisli Maybe LBS.ByteString) Char)
 
 class FromPgMessage a where
   msgParser :: PgMsgParser a


### PR DESCRIPTION
Follow-up to the discussion in #34.

Two changes, one per commit:

 - `Hpgsql.Msgs`: derive `PgMsgParser`'s `Applicative`/`Alternative` via `Kleisli (Kleisli Maybe LBS.ByteString) Char` instead of `ReaderT`. `Kleisli` is the `a -> m b` newtype from base, and its instances are the same pointwise lift into `Maybe` that `ReaderT` provides, so the instances stay lawful by construction.
- `Hpgsql.Connection`: both connection string parsers ran in `ExceptT String Identity`, which is isomorphic to the `Either String` they already return. Using `Either` directly removes the last use of `transformers`, so the dependency is dropped from `build-depends`.

Behavior is unchanged in both cases: `Kleisli`'s `<|>` keeps `Maybe`'s left bias (and carries the same INLINE pragma `ReaderT`'s does), and `ExceptT`'s bind and applicative short-circuit on the first error exactly like `Either`'s.

Verified with `nix-build -A hpgsql` on ghc967, ghc984, ghc9103 and ghc9122, and `-A testsPg18` / `-A hpgsqlSimpleCompatTestsPg18` -
133 examples, 0 failures, including the `LibPqConnStringParsingSpec` you added in #41, which covers the parsers this touches. hlint and fourmolu are clean.