### PR TITLE
Fix monadic row decoder's absence of type-checking

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -128,12 +128,12 @@ jobs:
 
     - name: Check code is formatted
       run: |
-        nix-shell --run 'run format-hs'
+        nix-shell --run 'run format'
         if [ -n "$(git diff --name-only)" ]; then
           echo "The following files are not properly formatted:"
           git diff --name-only
           echo ""
-          echo "Run 'run format-hs' locally and commit the changes."
+          echo "Run 'run format' locally and commit the changes."
           exit 1
         fi
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Commands:
   benchmarks      Runs benchmarks with a postgresql DB listening.
   bench-single    Runs the benchmarks executable without all the CSV-producing and memory usage collecting tooling around it.
   ci-tests        Runs all tests that CI runs, exactly like CI runs them.
-  format-hs       Formats all Haskell files with fourmolu.
+  format          Formats all Haskell files with fourmolu and lints with hlint.
   tests           Runs all tests.
   tests-stress    Runs tests 100 times, reporting how many passed and how many failed.
   tests-compat    Runs hpgsql-simple-compat's tests.

--- a/Runfile
+++ b/Runfile
@@ -47,8 +47,8 @@ ci-tests:
 
 
 ##
-# Formats all Haskell files with fourmolu.
-format-hs:
+# Formats all Haskell files with fourmolu and lints with hlint.
+format:
     set -eo pipefail
 
     readarray -d '' FILES < <(git ls-files -z '*.hs')
@@ -57,6 +57,9 @@ format-hs:
         echo "Formatting $f..."
         fourmolu --mode inplace "$f"
     done
+
+    echo "--- Running hlint"
+    hlint .
 
 ##
 # Runs all tests.
@@ -77,9 +80,6 @@ tests:
             nix-shell -A "shellPg${pg}" ./default.nix --run "./scripts/run-tests-db-internal.sh $TARGS"
         fi
     done
-
-    echo "--- Running hlint"
-    hlint .
 
 ##
 # Runs tests 100 times, reporting how many passed and how many failed.

--- a/hpgsql-tests/BasicTestsSpec.hs
+++ b/hpgsql-tests/BasicTestsSpec.hs
@@ -5,6 +5,7 @@ import Data.Text (Text)
 import DbUtils
   ( aroundConn,
     irrecoverableErrorWithMsg,
+    irrecoverableErrorWithMsgAndStmt,
     pgErrorMustContain,
     withRollback,
   )
@@ -13,7 +14,7 @@ import Hpgsql.Connection (getParameterStatus)
 import Hpgsql.Encoding (FromPgRow (..))
 import Hpgsql.Encoding.RowDecoderMonadic (toMonadicRowDecoder)
 import Hpgsql.Pipeline (pipelineExec, pipelineExec_, runPipeline)
-import Hpgsql.Query (mkQuery, sql)
+import Hpgsql.Query (mkQuery, sql, sqlPrep)
 import Hpgsql.Transaction (TransactionStatus (..), transactionStatus)
 import Hpgsql.Types (Only (..))
 import Streaming (Of (..))
@@ -125,17 +126,23 @@ queryMWithismatchInNumberOfColumns :: HPgConnection -> IO ()
 queryMWithismatchInNumberOfColumns conn = do
   queryWith (rowDecoder @(Bool, Bool)) conn "select 1, 2, 3"
     `shouldThrow` pgErrorMustContain "select 1, 2, 3" [(ErrorCode, "08P01"), (ErrorHumanReadableMsg, "bind message has 2 result formats but query has 3 columns")]
+  queryMWith (toMonadicRowDecoder $ rowDecoder @(Bool, Bool)) conn "select 1, 2, 3"
+    `shouldThrow` irrecoverableErrorWithMsgAndStmt "select 1, 2, 3" "Query result column types do not match expected column types"
+  queryWith (rowDecoder @(Int, Int, Int, String)) conn "select 1, 2, 3"
+    `shouldThrow` pgErrorMustContain "select 1, 2, 3" [(ErrorCode, "08P01"), (ErrorHumanReadableMsg, "bind message has 4 result formats but query has 3 columns")]
+  queryMWith (toMonadicRowDecoder $ rowDecoder @(Int, Int, Int, String)) conn "select 1, 2, 3"
+    `shouldThrow` irrecoverableErrorWithMsgAndStmt "select 1, 2, 3" "More columns expected by the row parser than found in query results. Expected 4 but got 3"
 
 queryMWithismatchInTypesOfColumns :: HPgConnection -> IO ()
 queryMWithismatchInTypesOfColumns conn = do
   queryWith (rowDecoder @(Bool, Bool)) conn "select 1, 2"
     `shouldThrow` irrecoverableErrorWithMsg "Query result column types do not match expected column types"
+  queryMWith (toMonadicRowDecoder $ rowDecoder @(Bool, Bool)) conn "select 1, 2"
+    `shouldThrow` irrecoverableErrorWithMsg "Query result column types do not match expected column types"
 
 queryThatErrorsFollowedBySuccessfulQuery :: HPgConnection -> IO ()
 queryThatErrorsFollowedBySuccessfulQuery conn = do
   -- TODO: Test empty query string
-  -- TODO: Test multiple statements inside the same query string
-  -- TODO: Test error statement + empty statement + normal statement all inside the same query string
   queryWith (rowDecoder @(Only Bool)) conn "select 1/(x - 2) > 0 from generate_series(1,2) subq(x)"
     `shouldThrow` pgErrorMustContain "select 1/(x - 2) > 0 from generate_series(1,2) subq(x)" [(ErrorCode, "22012"), (ErrorHumanReadableMsg, "division by zero")]
   queryWith (rowDecoder @(Only Bool)) conn "select FALSE from generate_series(1,2) subq(x)"
@@ -163,13 +170,16 @@ wellFormedPreparedStatements conn = withRollback conn $ do
   execute_ conn "DROP TABLE xx;"
 
 preparedStatementWrongTypes :: HPgConnection -> IO ()
-preparedStatementWrongTypes conn =
-  queryWith (rowDecoder @(Int, Text)) conn "SELECT 1, 2" `shouldThrow` irrecoverableErrorWithMsg "Query result column types do not match expected column types"
+preparedStatementWrongTypes conn = do
+  queryWith (rowDecoder @(Int, Text)) conn [sqlPrep|SELECT 1, 2|] `shouldThrow` irrecoverableErrorWithMsg "Query result column types do not match expected column types"
+  queryMWith (toMonadicRowDecoder $ rowDecoder @(Int, Text)) conn [sqlPrep|SELECT 1, 2|] `shouldThrow` irrecoverableErrorWithMsg "Query result column types do not match expected column types"
 
 preparedStatementWrongTypesThrowsEvenWithZeroReturnedRows :: HPgConnection -> IO ()
-preparedStatementWrongTypesThrowsEvenWithZeroReturnedRows conn =
-  -- TODO: Test prepared statement with a query that fails the parser
-  queryWith (rowDecoder @(Int, Text)) conn "SELECT 1, 2 WHERE FALSE -- No rows still throws" `shouldThrow` irrecoverableErrorWithMsg "Query result column types do not match expected column types"
+preparedStatementWrongTypesThrowsEvenWithZeroReturnedRows conn = do
+  queryWith (rowDecoder @(Int, Text)) conn [sqlPrep|SELECT 1, 2 WHERE FALSE -- No rows still throws|] `shouldThrow` irrecoverableErrorWithMsg "Query result column types do not match expected column types"
+  -- Monadic Row Decoder doesn't check types per query; it checks them per field per row. This
+  -- is because a monadic row decoder can change how it decodes a field depending on the values.
+  queryMWith (toMonadicRowDecoder $ rowDecoder @(Int, Text)) conn [sqlPrep|SELECT 1, 2 WHERE FALSE|] `shouldReturn` []
 
 checkCommandCounts :: HPgConnection -> IO ()
 checkCommandCounts conn = withRollback conn $ do

--- a/hpgsql/src/Hpgsql/Encoding.hs
+++ b/hpgsql/src/Hpgsql/Encoding.hs
@@ -16,7 +16,7 @@
 -- > persons :: [Person] <- query conn "SELECT * FROM persons"
 --
 -- Note that Hpgsql's `RowDecoder` does not have a `Monad` instance because that allows it to
--- type check query results and field counts even when queries return zero rows. If you need
+-- type check query results and field counts only once per query. If you need
 -- to write a row decoder that is monadic (because decoding can change depending on the values
 -- of fields), check "Hpgsql.Encoding.RowDecoderMonadic".
 module Hpgsql.Encoding

--- a/hpgsql/src/Hpgsql/Encoding/RowDecoderMonadic.hs
+++ b/hpgsql/src/Hpgsql/Encoding/RowDecoderMonadic.hs
@@ -15,8 +15,9 @@ import qualified Hpgsql.SimpleParser as Parser
 -- You should prefer to use @Hpgsql.Encoding.RowDecoder@ (through @FromPgRow@ instances)
 -- instead of this, and use this only if your row decoder is complex enough that
 -- decoded fields can change the behaviour of other decoded fields.
--- The regular @RowDecoder@ can even type-check queries that return no results, while
--- this can't.
+-- The regular @RowDecoder@ pays the price of type-checking only once per query and can
+-- even type-check queries that return no results, while this pays the price of type-checking
+-- for every field of every row, and won't type-check zero-rows results.
 -- Look for the 'query' and 'pipeline' functions with an 'M' in them for ways to query
 -- with this kind of row decoder.
 newtype RowDecoderMonadic a = RowDecoderMonadic
@@ -44,9 +45,9 @@ instance Monad RowDecoderMonadic where
     let RowDecoderMonadic {fullRowDecoder = parserOfRemainder} = f row
     parserOfRemainder cs0 {colsLeftToParse = List.drop numColsParsed cs0.colsLeftToParse}
 
--- | Takes an Applicative row parser (which can type-check result rows before even fetching
--- any rows from the response) and transforms it into a Monadic row parser, which has no such
--- type-checking.
+-- | Takes an Applicative row parser (which type-checks result rows only once per query)
+-- and transforms it into a Monadic row parser, which is more flexible, but pays the
+-- price of type-checking every field in every row returned in queries.
 toMonadicRowDecoder :: RowDecoder a -> RowDecoderMonadic a
 toMonadicRowDecoder RowDecoder {fullRowDecoder, numExpectedColumns, rowColumnsTypeCheck} = RowDecoderMonadic $ \cs -> do
   let numActualCols = length cs.colsLeftToParse

--- a/hpgsql/src/Hpgsql/Encoding/RowDecoderMonadic.hs
+++ b/hpgsql/src/Hpgsql/Encoding/RowDecoderMonadic.hs
@@ -5,6 +5,7 @@ module Hpgsql.Encoding.RowDecoderMonadic
   )
 where
 
+import Control.Monad (unless)
 import Data.Bifunctor (first)
 import qualified Data.List as List
 import Hpgsql.Encoding (FieldInfo, RowDecoder (..))
@@ -47,9 +48,12 @@ instance Monad RowDecoderMonadic where
 -- any rows from the response) and transforms it into a Monadic row parser, which has no such
 -- type-checking.
 toMonadicRowDecoder :: RowDecoder a -> RowDecoderMonadic a
-toMonadicRowDecoder RowDecoder {fullRowDecoder, numExpectedColumns} = RowDecoderMonadic $ \cs -> do
+toMonadicRowDecoder RowDecoder {fullRowDecoder, numExpectedColumns, rowColumnsTypeCheck} = RowDecoderMonadic $ \cs -> do
   let numActualCols = length cs.colsLeftToParse
   case compare numActualCols numExpectedColumns of
-    EQ -> (,numExpectedColumns) <$> fullRowDecoder cs.colsLeftToParse
-    GT -> (,numExpectedColumns) <$> fullRowDecoder (List.take numExpectedColumns cs.colsLeftToParse)
-    LT -> fail $ "More number of columns expected by the row parser than found in query results. Expected " ++ show numExpectedColumns ++ " but got " ++ show numActualCols
+    LT -> fail $ "More columns expected by the row parser than found in query results. Expected " ++ show numExpectedColumns ++ " but got " ++ show numActualCols
+    _ -> do
+      let colsForNow = List.take numExpectedColumns cs.colsLeftToParse
+      let typecheckedCols = rowColumnsTypeCheck colsForNow
+      unless (all snd typecheckedCols) $ fail "Query result column types do not match expected column types"
+      (,numExpectedColumns) <$> fullRowDecoder colsForNow

--- a/hpgsql/src/Hpgsql/Internal.hs
+++ b/hpgsql/src/Hpgsql/Internal.hs
@@ -113,7 +113,7 @@ import Control.Concurrent.MVar (MVar, newMVar)
 import Control.Concurrent.STM (STM, TVar)
 import qualified Control.Concurrent.STM as STM
 import Control.Exception.Safe (Exception (..), MonadThrow, SomeException, bracket, bracketOnError, finally, handleJust, mask, mask_, onException, throw, toException, tryJust)
-import Control.Monad (forM, forM_, join, unless, void, when)
+import Control.Monad (forM, forM_, join, replicateM, unless, void, when)
 import Data.ByteString (ByteString)
 import qualified Data.ByteString as BS
 import Data.ByteString.Internal (w2c)
@@ -1420,7 +1420,7 @@ consumeStreamingResults rp conn qryId = S.effect $ do
           S.concat $
             S.mapM
               ( \(DataRows (rowColumnData, nRows)) ->
-                  case Parser.parseOnly (Parser.parseExactlyN nRows rowparser <* Parser.endOfInput) rowColumnData of
+                  case Parser.parseOnly (replicateM nRows rowparser <* Parser.endOfInput) rowColumnData of
                     Parser.ParseOk rows -> pure rows
                     Parser.ParseFail err -> throwIrrecoverableErrorWithStatement qText $ "Failed parsing a row: " <> Text.pack (show err)
               )

--- a/hpgsql/src/Hpgsql/Internal.hs
+++ b/hpgsql/src/Hpgsql/Internal.hs
@@ -507,7 +507,7 @@ receiveNextMsgWithMaskedContinuation conn parser f =
     Left (msgIdentChar, mPgError) -> throw IrrecoverableHpgsqlError {hpgsqlDetails = "Could not parse postgres message with ident char " <> Text.pack (show msgIdentChar) <> ". This is an internal error in Hpgsql. Please report it.", innerException = toException <$> mPgError, relatedStatement = Nothing}
 
 data ReceiveWhat a b where
-  ReceiveDataRows :: ReceiveWhat DataRow ByteString
+  ReceiveDataRows :: ReceiveWhat DataRow (ByteString, Int)
   ReceiveArbitraryMsg :: PgMsgParser a -> (Either (Char, Maybe PostgresError) a -> STM b) -> ReceiveWhat a b
 
 -- | Masks asynchronous exceptions in between the moment the message is extracted from
@@ -586,11 +586,11 @@ receiveNextMsgGeneric conn@HPgConnection {socket, recvBuffer} receiveWhat = do
           -- Parse as many DataRows as we can to do as much work as we can per buffer "churn"
           let fullBuf = LBS.toStrict nowBuf
            in case Parser.parseOnly Parser.parseManyRows fullBuf of
-                Parser.ParseOk unconsumedBufferBegin | unconsumedBufferBegin.idx > 0 -> do
+                Parser.ParseOk (unconsumedBufferBegin, nRowsParsed) | nRowsParsed > 0 -> do
                   let (msgs, unconsumedBuffer) = BS.splitAt unconsumedBufferBegin.idx fullBuf
-                  debugPrint $ "Received one or more messages with total length " ++ show (BS.length msgs)
-                  pure (LBS.fromStrict unconsumedBuffer, Just msgs)
-                _ -> handleUnexpectedMsg $ const $ pure "" -- No error when we stop receiving DataRows, only emptiness
+                  debugPrint $ "Received " ++ show nRowsParsed ++ " messages with total length " ++ show (BS.length msgs)
+                  pure (LBS.fromStrict unconsumedBuffer, Just (msgs, nRowsParsed))
+                _ -> handleUnexpectedMsg $ const $ pure ("", 0) -- No error when we stop receiving DataRows, only emptiness
         ReceiveArbitraryMsg parser f ->
           case parsePgMessage msgIdentChar fullMsg parser of
             Just msg -> do
@@ -844,7 +844,9 @@ receiveOutstandingResponseMsgsAtomically thisThreadId conn qryId = do
           }
       pure (Just respMsg, newState)
 
-newtype DataRows = DataRows ByteString
+-- | A sequence of all the bytes of one or more DataRow messages and the total
+-- number of DataRow messages.
+newtype DataRows = DataRows (ByteString, Int)
 
 -- | After sending one or more queries to the backend, run this function for each query to fetch that query's results.
 -- You must call the returned IO function and consume the returned Stream completely until you get to the
@@ -891,10 +893,10 @@ consumeResults conn qryId = do
       let allOtherRows =
             S.unfold
               ( \() -> do
-                  mRow <- receiveNextMsgGeneric conn ReceiveDataRows
-                  case mRow of
-                    rows | not (BS.null rows) -> pure $ Right (DataRows rows :> ())
-                    _ -> do
+                  mRow@(_, nRows) <- receiveNextMsgGeneric conn ReceiveDataRows
+                  if nRows > 0
+                    then pure $ Right (DataRows mRow :> ())
+                    else do
                       stateAfterNextMsg <- snd <$> receiveOutstandingResponseMsgsAtomically thisThreadId conn qryId
                       case stateAfterNextMsg of
                         ErrorResponseReceived _ err -> do
@@ -910,7 +912,7 @@ consumeResults conn qryId = do
           finalStream = case mDataRow of
             Nothing -> allOtherRows
             Just dr ->
-              DataRows dr.fullDataRow `S.cons` allOtherRows
+              DataRows (dr.fullDataRow, 1) `S.cons` allOtherRows
       pure (mERowDesc, finalStream)
   where
     receiveReadyForQueryIfNecessary :: WeakThreadId -> IO ()
@@ -1417,8 +1419,8 @@ consumeStreamingResults rp conn qryId = S.effect $ do
         errOrCmdComplete <-
           S.concat $
             S.mapM
-              ( \(DataRows rowColumnData) ->
-                  case Parser.parseOnly (Parser.parseMany rowparser <* Parser.endOfInput) rowColumnData of
+              ( \(DataRows (rowColumnData, nRows)) ->
+                  case Parser.parseOnly (Parser.parseExactlyN nRows rowparser <* Parser.endOfInput) rowColumnData of
                     Parser.ParseOk rows -> pure rows
                     Parser.ParseFail err -> throwIrrecoverableErrorWithStatement qText $ "Failed parsing a row: " <> Text.pack (show err)
               )

--- a/hpgsql/src/Hpgsql/SimpleParser.hs
+++ b/hpgsql/src/Hpgsql/SimpleParser.hs
@@ -24,9 +24,11 @@ module Hpgsql.SimpleParser
     takeDataRow,
     parseManyRows,
     skip,
+    parseExactlyN,
   )
 where
 
+import Control.Monad (replicateM)
 import Data.ByteString (ByteString)
 import qualified Data.ByteString as BS
 import Data.Int (Int16, Int32, Int64)
@@ -151,12 +153,21 @@ parseMany p = Parser $ \idx' bs' _kf ks -> let (vs, restIdx) = go idx' bs' in ks
       ParseFail _ -> ([], idx)
 {-# INLINE parseMany #-}
 
-parseManyRows :: Parser ByteStringIdx
-parseManyRows = Parser $ \idx' bs' _kf ks -> let restIdx = go idx' bs' in ks restIdx restIdx bs'
+-- | Applies the supplied parser repeatedly exactly `n` times.
+-- Fails if any of them fails.
+parseExactlyN :: Int -> Parser a -> Parser [a]
+parseExactlyN = replicateM
+{-# INLINE parseExactlyN #-}
+
+-- | Parses as many PG rows as there are available, returns
+-- the index/offset of the first left-unparsed byte and the
+-- number of rows parsed.
+parseManyRows :: Parser (ByteStringIdx, Int)
+parseManyRows = Parser $ \idx' bs' _kf ks -> let (restIdx, nParsed) = go idx' bs' 0 in ks (restIdx, nParsed) restIdx bs'
   where
-    go idx bs = case parseOnlyOffset takeDataRow idx bs of
-      ParseOk unconsumedIdx -> go unconsumedIdx bs
-      ParseFail _ -> idx
+    go idx bs !nParsedSoFar = case parseOnlyOffset takeDataRow idx bs of
+      ParseOk unconsumedIdx -> go unconsumedIdx bs (nParsedSoFar + 1)
+      ParseFail _ -> (idx, nParsedSoFar)
 {-# INLINE parseManyRows #-}
 
 -- | Succeeds only when the input has been fully consumed.

--- a/hpgsql/src/Hpgsql/SimpleParser.hs
+++ b/hpgsql/src/Hpgsql/SimpleParser.hs
@@ -24,11 +24,9 @@ module Hpgsql.SimpleParser
     takeDataRow,
     parseManyRows,
     skip,
-    parseExactlyN,
   )
 where
 
-import Control.Monad (replicateM)
 import Data.ByteString (ByteString)
 import qualified Data.ByteString as BS
 import Data.Int (Int16, Int32, Int64)
@@ -152,12 +150,6 @@ parseMany p = Parser $ \idx' bs' _kf ks -> let (vs, restIdx) = go idx' bs' in ks
       ParseOk (unconsumedIdx, v) -> let (vs, rest) = go unconsumedIdx bs in (v : vs, rest)
       ParseFail _ -> ([], idx)
 {-# INLINE parseMany #-}
-
--- | Applies the supplied parser repeatedly exactly `n` times.
--- Fails if any of them fails.
-parseExactlyN :: Int -> Parser a -> Parser [a]
-parseExactlyN = replicateM
-{-# INLINE parseExactlyN #-}
 
 -- | Parses as many PG rows as there are available, returns
 -- the index/offset of the first left-unparsed byte and the


### PR DESCRIPTION
We were only checking field counts before. This definitely slipped through.

This also improves performance and total allocated memory by ~1% .